### PR TITLE
starting circleci service

### DIFF
--- a/.circleci.yml
+++ b/.circleci.yml
@@ -1,0 +1,9 @@
+version: 2
+jobs:
+  build:
+    docker:
+      # the primary container, where your job's commands are run
+      - image: nlescjcer/champ_docker:devel
+    steps:
+      - checkout # check out the code in the project directory
+      - run: echo "hello world" # run the `echo` command


### PR DESCRIPTION
Used [circleci](https://circleci.com/) together with [champ_docker image](https://hub.docker.com/r/nlescjcer/champ_docker/) to run continuous integration