### PR TITLE
Change cblock sr_mat_n nconf to nconf_n, and cblock control n_conf to nconf.

### DIFF
--- a/src/vmc/3dgrid.f
+++ b/src/vmc/3dgrid.f
@@ -16,7 +16,7 @@ c----------------------------------------------------------------------
 
       use atom, only: znuc, cent, iwctype, ncent
       use ghostatom, only: newghostype, nghostcent
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use grid3d_param, only: endpt, nstep3d, origin, step3d
 
       implicit real*8(a-h,o-z)

--- a/src/vmc/3dgrid_orbitals.f
+++ b/src/vmc/3dgrid_orbitals.f
@@ -11,10 +11,10 @@ c Written by A. Scemama, adapted from C. Umrigar's 2D routines
      &phin
       use wfsec, only: iwf, iwftype, nwftype
       use coefs, only: coef, nbasis, norb
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use coefs, only: coef, nbasis, norb
       use phifun, only: d2phin, dphin, phin
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use grid3d_param, only: endpt, nstep3d, origin, step3d
       use orbital_num_lag, only: denom, step_inv
 

--- a/src/vmc/acuest.f
+++ b/src/vmc/acuest.f
@@ -23,7 +23,7 @@ c routine to accumulate estimators for energy etc.
       use step, only: ekin, ekin2, rprob, suc, trunfb, try
       use contr3, only: mode
 
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use pseudo, only: lpot, nloc, vps, vpso
 
       use qua, only: nquad, wq, xq, xq0, yq, yq0, zq, zq0

--- a/src/vmc/acuest_write.f
+++ b/src/vmc/acuest_write.f
@@ -12,7 +12,7 @@ c routine to write out estimators for energy etc.
       use forcest, only: fcm2, fcum
       use forcewt, only: wcum, wsum
       use contr3, only: mode
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
 
       implicit real*8(a-h,o-z)
 

--- a/src/vmc/dumper.f
+++ b/src/vmc/dumper.f
@@ -19,7 +19,7 @@ c job where it left off
       use mpiconf, only: idtask, nproc, wid
       use step, only: ekin, ekin2, rprob, suc, trunfb, try
 
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use pseudo, only: lpot, nloc, vps, vpso
 
       use qua, only: nquad, wq, xq, xq0, yq, yq0, zq, zq0

--- a/src/vmc/dumper_more.f
+++ b/src/vmc/dumper_more.f
@@ -27,7 +27,7 @@ c job where it left off
       use wfsec, only: iwf, iwftype, nwftype
       use coefs, only: coef, nbasis, norb
       use const2, only: deltar, deltat
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use basis, only: zex, betaq, n1s, n2s, n2p, n3s, n3p, n3dzr, n3dx2, n3dxy, n3dxz, n3dyz,
      & n4s, n4p, n4fxxx, n4fyyy, n4fzzz, n4fxxy, n4fxxz, n4fyyx, n4fyyz,
      & n4fzzx, n4fzzy, n4fxyz, nsa, npa, ndzra, ndz2a, ndxya, ndxza, ndyza, ndx2a

--- a/src/vmc/fin_reduce.f
+++ b/src/vmc/fin_reduce.f
@@ -11,7 +11,7 @@ c MPI version written by Claudia Filippi
       use mpiconf, only: idtask, nproc, wid
       use step, only: ekin, ekin2, rprob, suc, trunfb, try
 
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       implicit real*8(a-h,o-z)
 
 

--- a/src/vmc/finwrt.f
+++ b/src/vmc/finwrt.f
@@ -20,7 +20,7 @@ c routine to print out final results
       use step, only: ekin, ekin2, rprob, suc, trunfb, try
       use tmpnode, only: distance_node_sum
       use contr3, only: mode
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use contrl_per, only: iperiodic,ibasis
 
       implicit real*8(a-h,o-z)

--- a/src/vmc/finwrt_more.f
+++ b/src/vmc/finwrt_more.f
@@ -10,7 +10,7 @@ c written by Claudia Filippi
       use estsum, only: acc, esum, esum1, pesum, r2sum, tjfsum, tpbsum
       use mpiconf, only: idtask, nproc, wid
       use optwf_corsam, only: add_diag_tmp, energy, energy_err, force, force_err
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       implicit real*8(a-h,o-z)
 
 

--- a/src/vmc/force_analytic.f
+++ b/src/vmc/force_analytic.f
@@ -311,7 +311,7 @@ c-----------------------------------------------------------------------
       subroutine force_analy_fin(wcum,iblk,eave)
       use atom, only: znuc, cent, pecent, iwctype, nctype, ncent
       use force_fin, only: da_energy_ave, da_energy_err
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use da_energy_sumcum, only: da_energy_cm2, da_energy_cum, da_energy_sum, da_psi_cum, da_psi_sum
 
       use force_analy, only: iforce_analy
@@ -348,7 +348,7 @@ c-----------------------------------------------------------------------
 c-----------------------------------------------------------------------
       subroutine force_analy_dump(iu)
       use atom, only: znuc, cent, pecent, iwctype, nctype, ncent
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use da_energy_sumcum, only: da_energy_cm2, da_energy_cum, da_energy_sum, da_psi_cum, da_psi_sum
 
       use force_analy, only: iforce_analy
@@ -370,7 +370,7 @@ c-----------------------------------------------------------------------
 c-----------------------------------------------------------------------
       subroutine force_analy_rstrt(iu)
       use atom, only: znuc, cent, pecent, iwctype, nctype, ncent
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use da_energy_sumcum, only: da_energy_cm2, da_energy_cum, da_energy_sum, da_psi_cum, da_psi_sum
 
       use force_analy, only: iforce_analy

--- a/src/vmc/m_common.f90
+++ b/src/vmc/m_common.f90
@@ -286,21 +286,21 @@
  end module constant
 
  module contrl
-  !> Arguments: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+  !> Arguments: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
   use precision_kinds, only: dp
   include 'vmc.h'
 
    integer  :: idump
    integer  :: irstar
    integer  :: isite
-   integer  :: n_conf
+   integer  :: nconf
    integer  :: nblk
    integer  :: nblkeq
    integer  :: nconf_new
    integer  :: nstep
 
    private 
-   public :: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep 
+   public :: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep 
    save
  end module contrl
 
@@ -2383,7 +2383,7 @@ module spc2
  end module sr_index
 
  module sr_mat_n
-   !> Arguments: elocal, h_sr, jefj, jfj, jhfj, nconf, obs, s_diag, s_ii_inv, sr_ho, sr_o, wtg, obs_tot
+   !> Arguments: elocal, h_sr, jefj, jfj, jhfj, nconf_n, obs, s_diag, s_ii_inv, sr_ho, sr_o, wtg, obs_tot
    use precision_kinds, only: dp
    include 'sr.h'
    include 'mstates.h'
@@ -2393,7 +2393,7 @@ module spc2
    integer  :: jefj
    integer  :: jfj
    integer  :: jhfj
-   integer  :: nconf
+   integer  :: nconf_n 
    real(dp) :: obs(MOBS,MSTATES)
    real(dp) :: s_diag(MPARM,MSTATES)
    real(dp) :: s_ii_inv(MPARM)
@@ -2403,7 +2403,7 @@ module spc2
    real(dp) :: obs_tot(MOBS,MSTATES)
 
    private
-   public :: elocal, h_sr, jefj, jfj, jhfj, nconf, obs, s_diag, s_ii_inv, sr_ho, sr_o, wtg, obs_tot
+   public :: elocal, h_sr, jefj, jfj, jhfj, nconf_n, obs, s_diag, s_ii_inv, sr_ho, sr_o, wtg, obs_tot
    save
  end module sr_mat_n
 

--- a/src/vmc/mc_configs.f
+++ b/src/vmc/mc_configs.f
@@ -7,7 +7,7 @@
      &psido, psijo, rminn, rminno, rmino, rminon, rvminn, rvminno, rvmino, rvminon, tjfn, tjfo,
      &vnew, vold, xnew, xold
       use mpiconf, only: idtask, nproc, wid
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       implicit real*8(a-h,o-z)
 
 

--- a/src/vmc/mmpol_vmc.f
+++ b/src/vmc/mmpol_vmc.f
@@ -44,7 +44,7 @@
 c-----------------------------------------------------------------------
       subroutine mmpol_fin(wcum,iblk)
 
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use mmpol_cntrl, only: icall_mm, ich_mmpol, immpol, immpolprt, isites_mmpol
       use mmpol_parms, only: chmm, nchmm, rqq, x_mmpol
       use mmpol_averages, only: cmmpol_cm2, cmmpol_cum, cmmpol_sum, dmmpol_cm2, dmmpol_cum, dmmpol_sum

--- a/src/vmc/multiple_states.f
+++ b/src/vmc/multiple_states.f
@@ -36,7 +36,7 @@ c----------------------------------------------------------------------
       end
 c----------------------------------------------------------------------
       subroutine efficiency_prt(passes)
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       implicit real*8(a-h,o-z)
 
       include 'vmc.h'

--- a/src/vmc/optci.f
+++ b/src/vmc/optci.f
@@ -316,7 +316,7 @@ c-----------------------------------------------------------------------
       use gradhess_ci, only: grad_ci, h_ci, s_ci
       use linear_norm, only: oav, ci_oav
       use optwf_contrl, only: ioptci, ioptjas, ioptorb, nparm
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       implicit real*8(a-h,o-z)
 
 

--- a/src/vmc/optorb.f
+++ b/src/vmc/optorb.f
@@ -789,7 +789,7 @@ c-----------------------------------------------------------------------
 
       use optorb_mix, only: iwmix_virt, norbopt, norbvirt
       use coefs, only: coef, nbasis, norb
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use dorb_m, only: iworbd
       use optorb, only: dmat_diag, irrep, orb_energy
       use optorb_cblock, only: norbterm, norbprim, idump_blockav

--- a/src/vmc/optwf_dl.f
+++ b/src/vmc/optwf_dl.f
@@ -6,17 +6,12 @@
 
       use optwf_contrl, only: ioptci, ioptjas, ioptorb, nparm
       use optwf_corsam, only: add_diag_tmp, energy, energy_err, force, force_err
-      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf, obs, s_diag, s_ii_inv, sr_ho,
+      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf_n, obs, s_diag, s_ii_inv, sr_ho,
      &sr_o, wtg
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use force_analy, only: iforce_analy
+
       implicit real*8(a-h,o-z)
-
-
-
-
-
-
 
       character*20 dl_alg
 

--- a/src/vmc/optwf_dl_iter.f
+++ b/src/vmc/optwf_dl_iter.f
@@ -1,5 +1,5 @@
       subroutine dl_iter(iter,nparm,dl_alg,dl_mom,sr_tau,dl_momentum,dl_EG_sq,dl_EG,deltap,parameters)
-      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf, obs, s_diag, s_ii_inv, sr_ho,
+      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf_n, obs, s_diag, s_ii_inv, sr_ho,
      &sr_o, wtg
       implicit real*8(a-h,o-z)
 

--- a/src/vmc/optwf_dl_more.f
+++ b/src/vmc/optwf_dl_more.f
@@ -1,21 +1,18 @@
       subroutine dl_more(iter,nparm,dl_momentum,dl_EG_sq,dl_EG,deltap,parameters)
 
       use mpiconf, only: idtask, nproc
-      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf, obs, s_diag, s_ii_inv, sr_ho,
+      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf_n, obs, s_diag, s_ii_inv, sr_ho,
      &sr_o, wtg
-      implicit real*8(a-h,o-z)
 
+      implicit real*8(a-h,o-z)
 
       character*20 dl_alg
 
       include 'mpif.h'
-
       include 'vmc.h'
       include 'force.h'
       include 'mstates.h'
       include 'sr.h'
-
-
 
       dimension deltap(*),dl_momentum(*),dl_EG_sq(*),dl_EG(*),parameters(*)
 

--- a/src/vmc/optwf_handle_wf.f
+++ b/src/vmc/optwf_handle_wf.f
@@ -1024,7 +1024,7 @@ c store elocal and derivatives of psi for each configuration (call in vmc)
       use optwf_contrl, only: ioptci, ioptjas, ioptorb, nparm
       use optwf_func, only: ifunc_omega, omega, omega_hes
       use optwf_parms, only: nparmd, nparme, nparmg, nparmj, nparml, nparms
-      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf, obs, s_diag, s_ii_inv, sr_ho,
+      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf_n, obs, s_diag, s_ii_inv, sr_ho,
      &sr_o, wtg
       use deloc_dj_m, only: denergy
       use force_analy, only: iforce_analy
@@ -1076,7 +1076,7 @@ c store elocal and derivatives of psi for each configuration (call in vmc)
         sr_o(ii+istate,l)=psid(istate)
       enddo
       
-      nconf=l
+      nconf_n=l
 
       if(method.eq.'sr_n'.and.i_sr_rescale.eq.0.and.izvzb.eq.0.and.ifunc_omega.eq.0) return
 

--- a/src/vmc/optwf_lin_dav.f
+++ b/src/vmc/optwf_lin_dav.f
@@ -8,7 +8,7 @@
       use optwf_contrl, only: ioptci, ioptjas, ioptorb, nparm
       use optwf_corsam, only: add_diag_tmp, energy, energy_err, force, force_err
       use optwf_func, only: ifunc_omega, omega, omega_hes
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use force_analy, only: iforce_analy
       implicit real*8(a-h,o-z)
 

--- a/src/vmc/optwf_lin_dav_more.f
+++ b/src/vmc/optwf_lin_dav_more.f
@@ -7,7 +7,7 @@
       use optwf_contrl, only: ioptci, ioptjas, ioptorb
       use optwf_corsam, only: add_diag_tmp, energy, energy_err, force, force_err
       use optwf_parms, only: nparmd, nparme, nparmg, nparmj, nparml, nparms
-      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf, obs, s_diag, s_ii_inv, sr_ho,
+      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf_n, obs, s_diag, s_ii_inv, sr_ho,
      &sr_o, wtg, obs_tot
     
       implicit real*8(a-h,o-z)
@@ -204,7 +204,7 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       subroutine h_psi_energymin(ndim,nvec,psi,hpsi )
       use mpiconf, only: idtask, nproc
       use optwf_contrl, only: ioptci, ioptjas, ioptorb, nparm
-      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf, obs, s_diag, s_ii_inv, sr_ho,
+      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf_n, obs, s_diag, s_ii_inv, sr_ho,
      &sr_o, wtg, obs_tot
       implicit real*8(a-h,o-z)
 
@@ -243,18 +243,18 @@ c loop vec
 
       call MPI_BCAST(psi(1,ivec),ndim,MPI_REAL8,0,MPI_COMM_WORLD,ier)
 
-      do iconf=1,nconf
+      do iconf=1,nconf_n
        aux(iconf)=ddot(nparm,psi(i0+1,ivec),1,sr_ho(1,iconf),1)*wtg(iconf,1)
       enddo
       do i=1,nparm
-       hpsiloc(i+i0,ivec)=0.5d0*ddot(nconf,aux(1),1,sr_o(i,1),MPARM)
+       hpsiloc(i+i0,ivec)=0.5d0*ddot(nconf_n,aux(1),1,sr_o(i,1),MPARM)
       enddo
 
-      do iconf=1,nconf
+      do iconf=1,nconf_n
        aux(iconf)=ddot(nparm,psi(i0+1,ivec),1,sr_o(1,iconf),1)*wtg(iconf,1)
       enddo
       do i=1,nparm
-       hpsiloc(i+i0,ivec)=hpsiloc(i+i0,ivec)+0.5d0*ddot(nconf,aux(1),1,sr_ho(i,1),MPARM)
+       hpsiloc(i+i0,ivec)=hpsiloc(i+i0,ivec)+0.5d0*ddot(nconf_n,aux(1),1,sr_ho(i,1),MPARM)
       enddo
 
       call MPI_REDUCE(hpsiloc(1+i0,ivec),hpsi(1+i0,ivec),nparm,MPI_REAL8,MPI_SUM,0,MPI_COMM_WORLD,ier)
@@ -300,7 +300,7 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       subroutine s_psi_energymin(ndim,nvec,psi,spsi )
       use mpiconf, only: idtask, nproc
       use optwf_contrl, only: ioptci, ioptjas, ioptorb, nparm
-      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf, obs, s_diag, s_ii_inv, sr_ho,
+      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf_n, obs, s_diag, s_ii_inv, sr_ho,
      &sr_o, wtg, obs_tot
       implicit real*8(a-h,o-z)
 
@@ -335,11 +335,11 @@ c loop vec
 
       call MPI_BCAST(psi(1,ivec),ndim,MPI_REAL8,0,MPI_COMM_WORLD,ier)
 
-      do iconf=1,nconf
+      do iconf=1,nconf_n
        aux(iconf)=ddot(nparm,psi(i0+1,ivec),1,sr_o(1,iconf),1)*wtg(iconf,1)
       enddo
       do i=1,nparm
-       spsiloc(i+i0,ivec)=ddot(nconf,aux(1),1,sr_o(i,1),MPARM)
+       spsiloc(i+i0,ivec)=ddot(nconf_n,aux(1),1,sr_o(i,1),MPARM)
       enddo
 
       call MPI_REDUCE(spsiloc(1+i0,ivec),spsi(1+i0,ivec),nparm,MPI_REAL8,MPI_SUM,0,MPI_COMM_WORLD,ier)
@@ -377,7 +377,7 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       use mpiconf, only: idtask, nproc
       use optwf_contrl, only: ioptci, ioptjas, ioptorb, nparm
       use optwf_func, only: ifunc_omega, omega, omega_hes
-      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf, obs, s_diag, s_ii_inv, sr_ho,
+      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf_n, obs, s_diag, s_ii_inv, sr_ho,
      &sr_o, wtg, obs_tot
       implicit real*8(a-h,o-z)
 
@@ -421,23 +421,23 @@ c loop vec
 
       call MPI_BCAST(psi(1,ivec),ndim,MPI_REAL8,0,MPI_COMM_WORLD,ier)
 
-      do iconf=1,nconf
+      do iconf=1,nconf_n
        aux(iconf)=ddot(nparm,psi(i0+1,ivec),1,sr_ho(1,iconf),1)*wtg(iconf,1)
       enddo
       do i=1,nparm
-       hpsiloc(i+i0,ivec)=-0.5d0*ddot(nconf,aux(1),1,sr_o(i,1),MPARM)
+       hpsiloc(i+i0,ivec)=-0.5d0*ddot(nconf_n,aux(1),1,sr_o(i,1),MPARM)
       enddo
 
 c     do i=1,nparm+1
 c       write(6,*) 'H1 ',hpsi(i,ivec)
 c     enddo
 
-      do iconf=1,nconf
+      do iconf=1,nconf_n
        aux(iconf)=ddot(nparm,psi(i0+1,ivec),1,sr_o(1,iconf),1)*wtg(iconf,1)
       enddo
       do i=1,nparm
-       hpsiloc(i+i0,ivec)=hpsiloc(i+i0,ivec)-0.5d0*ddot(nconf,aux(1),1,sr_ho(i,1),MPARM)
-     &                                      +omega*ddot(nconf,aux(1),1,sr_o(i,1),MPARM)
+       hpsiloc(i+i0,ivec)=hpsiloc(i+i0,ivec)-0.5d0*ddot(nconf_n,aux(1),1,sr_ho(i,1),MPARM)
+     &                                      +omega*ddot(nconf_n,aux(1),1,sr_o(i,1),MPARM)
       enddo
 
       call MPI_REDUCE(hpsiloc(1+i0,ivec),hpsi(1+i0,ivec),nparm,MPI_REAL8,MPI_SUM,0,MPI_COMM_WORLD,ier)
@@ -491,7 +491,7 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       use mpiconf, only: idtask, nproc
       use optwf_contrl, only: ioptci, ioptjas, ioptorb, nparm
       use optwf_func, only: ifunc_omega, omega, omega_hes
-      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf, obs, s_diag, s_ii_inv, sr_ho,
+      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf_n, obs, s_diag, s_ii_inv, sr_ho,
      &sr_o, wtg, obs_tot
       implicit real*8(a-h,o-z)
 
@@ -546,20 +546,20 @@ c loop vec
 
       call MPI_BCAST(psi(1,ivec),ndim,MPI_REAL8,0,MPI_COMM_WORLD,ier)
 
-      do iconf=1,nconf
+      do iconf=1,nconf_n
        aux(iconf)=ddot(nparm,psi(i0+1,ivec),1,sr_o(1,iconf),1)*wtg(iconf,1)
       enddo
       do i=1,nparm
-       spsiloc(i+i0,ivec)=omega*omega*ddot(nconf,aux(1),1,sr_o(i,1),MPARM)
-     &                         -omega*ddot(nconf,aux(1),1,sr_ho(i,1),MPARM)
+       spsiloc(i+i0,ivec)=omega*omega*ddot(nconf_n,aux(1),1,sr_o(i,1),MPARM)
+     &                         -omega*ddot(nconf_n,aux(1),1,sr_ho(i,1),MPARM)
       enddo
 
-      do iconf=1,nconf
+      do iconf=1,nconf_n
        aux(iconf)=ddot(nparm,psi(i0+1,ivec),1,sr_ho(1,iconf),1)*wtg(iconf,1)
       enddo
       do i=1,nparm
-       spsiloc(i+i0,ivec)=spsiloc(i+i0,ivec)-omega*ddot(nconf,aux(1),1,sr_o(i,1),MPARM)
-     &                                            +ddot(nconf,aux(1),1,sr_ho(i,1),MPARM)
+       spsiloc(i+i0,ivec)=spsiloc(i+i0,ivec)-omega*ddot(nconf_n,aux(1),1,sr_o(i,1),MPARM)
+     &                                            +ddot(nconf_n,aux(1),1,sr_ho(i,1),MPARM)
       enddo
 
       call MPI_REDUCE(spsiloc(1+i0,ivec),spsi(1+i0,ivec),nparm,MPI_REAL8,MPI_SUM,0,MPI_COMM_WORLD,ier)
@@ -614,7 +614,7 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       use mpiconf, only: idtask, nproc
       use optwf_contrl, only: ioptci, ioptjas, ioptorb, nparm
       use optwf_func, only: ifunc_omega, omega, omega_hes
-      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf, obs, s_diag, s_ii_inv, sr_ho,
+      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf_n, obs, s_diag, s_ii_inv, sr_ho,
      &sr_o, wtg, obs_tot
       implicit real*8(a-h,o-z)
 
@@ -683,7 +683,7 @@ c loop vec
 
       call MPI_BCAST(psi(1,ivec),ndim,MPI_REAL8,0,MPI_COMM_WORLD,ier)
 
-      do iconf=1,nconf
+      do iconf=1,nconf_n
         hoz=ddot(nparm,psi(i0+1,ivec),1,sr_ho(1,iconf),1)
         oz =ddot(nparm,psi(i0+1,ivec),1,sr_o(1,iconf),1)
         aux0(iconf)=(hoz-oz*elocal(iconf,1))*wtg(iconf,1)
@@ -691,9 +691,9 @@ c loop vec
         aux2(iconf)=oz*wtg(iconf,1)
       enddo
       do i=1,nparm
-        hpsiloc(i+i0,ivec)=ddot(nconf,aux0(1),1,sr_ho(i,1),MPARM)
-     &                    +ddot(nconf,aux2(1),1,sr_o(i,1),MPARM)*var
-     &                    +ddot(nconf,aux1(1),1,sr_o(i,1),MPARM)
+        hpsiloc(i+i0,ivec)=ddot(nconf_n,aux0(1),1,sr_ho(i,1),MPARM)
+     &                    +ddot(nconf_n,aux2(1),1,sr_o(i,1),MPARM)*var
+     &                    +ddot(nconf_n,aux1(1),1,sr_o(i,1),MPARM)
       enddo
       call MPI_REDUCE(hpsiloc(1+i0,ivec),hpsi(1+i0,ivec),nparm,MPI_REAL8,MPI_SUM,0,MPI_COMM_WORLD,i)
 
@@ -739,7 +739,7 @@ c end loop vec
 ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       subroutine g_psi_lin_d( ndim, nvec, nb1, psi, ew )
 
-      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf, obs, s_diag, s_ii_inv, sr_ho,
+      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf_n, obs, s_diag, s_ii_inv, sr_ho,
      &sr_o, wtg, obs_tot
       implicit real*8(a-h,o-z)
 
@@ -811,7 +811,7 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
       use mpiconf, only: idtask, nproc
       use optwf_contrl, only: ioptci, ioptjas, ioptorb, nparm
-      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf, obs, s_diag, s_ii_inv, sr_ho,
+      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf_n, obs, s_diag, s_ii_inv, sr_ho,
      &sr_o, wtg, obs_tot
       implicit real*8(a-h,o-z)
 
@@ -843,7 +843,7 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
         do istate=1,nstates
           overlap_psiloc(ivec,istate)=0.d0
         enddo
-        do iconf=1,nconf
+        do iconf=1,nconf_n
           dum=ddot(nparm,psi(i0+1,ivec),1,sr_o(1,iconf),1)
           anorm_loc(ivec)=anorm_loc(ivec)+dum*dum*wtg(iconf,1)
           overlap_psiloc(ivec,1)=overlap_psiloc(ivec,1)+dum*wtg(iconf,1)

--- a/src/vmc/optwf_matrix_corsamp.f
+++ b/src/vmc/optwf_matrix_corsamp.f
@@ -10,7 +10,7 @@ c written by Claudia Filippi
       use optwf_corsam, only: add_diag, add_diag_tmp, energy, energy_err, force, force_err
       use optwf_parms, only: nparmd, nparme, nparmg, nparmj, nparml, nparms
       use wfsec, only: iwf, iwftype, nwftype
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       implicit real*8(a-h,o-z)
 
       include 'vmc.h'

--- a/src/vmc/optwf_mix_sa.f
+++ b/src/vmc/optwf_mix_sa.f
@@ -8,7 +8,7 @@
       use optwf_corsam, only: add_diag_tmp, energy, energy_err, force, force_err
       use optwf_func, only: ifunc_omega, omega, omega_hes
       use sa_check, only: energy_all, energy_err_all
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use force_analy, only: iforce_analy
       implicit real*8(a-h,o-z)
 

--- a/src/vmc/optwf_olbfgs.f
+++ b/src/vmc/optwf_olbfgs.f
@@ -1,23 +1,16 @@
       subroutine optwf_olbfgs
       use olbfgs, only: initialize_olbfgs
       use atom, only: znuc, cent, pecent, iwctype, nctype, ncent
-
       use const, only: pi, hb, etrial, delta, deltai, fbias, nelec, imetro, ipr
       use csfs, only: ccsf, cxdet, iadet, ibdet, icxdet, ncsf, nstates
-
       use optwf_contrl, only: ioptci, ioptjas, ioptorb, nparm
       use optwf_corsam, only: add_diag_tmp, energy, energy_err, force, force_err
-      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf, obs, s_diag, s_ii_inv, sr_ho,
+      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf_n, obs, s_diag, s_ii_inv, sr_ho,
      &sr_o, wtg
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use force_analy, only: iforce_analy
+
       implicit real*8(a-h,o-z)
-
-
-
-
-
-
 
       character*20 dl_alg
 

--- a/src/vmc/optwf_olbfgs_more.f
+++ b/src/vmc/optwf_olbfgs_more.f
@@ -1,8 +1,8 @@
       subroutine olbfgs_more(iter, nparm, deltap, parameters)
       use olbfgs, only: update_hessian, olbfgs_iteration
-
-      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf, obs, s_diag, s_ii_inv, sr_ho,
+      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf_n, obs, s_diag, s_ii_inv, sr_ho,
      &sr_o, wtg
+
       implicit real*8(a-h,o-z)
 
       character*20 dl_alg

--- a/src/vmc/optwf_sr.f
+++ b/src/vmc/optwf_sr.f
@@ -1,21 +1,14 @@
       subroutine optwf_sr
       use atom, only: znuc, cent, pecent, iwctype, nctype, ncent
-
       use const, only: pi, hb, etrial, delta, deltai, fbias, nelec, imetro, ipr
       use csfs, only: ccsf, cxdet, iadet, ibdet, icxdet, ncsf, nstates
-
       use optwf_contrl, only: ioptci, ioptjas, ioptorb, nparm
       use optwf_corsam, only: add_diag_tmp, energy, energy_err, force, force_err
       use optwf_func, only: ifunc_omega, omega, omega_hes
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use force_analy, only: iforce_analy
+
       implicit real*8(a-h,o-z)
-
-
-
-
-
-
 
       include 'vmc.h'
       include 'force.h'
@@ -182,7 +175,7 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       subroutine sr(nparm,deltap,sr_adiag,sr_eps,i)
 c solve S*deltap=h_sr (call in optwf)
 
-      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf, obs, s_diag, s_ii_inv, sr_ho,
+      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf_n, obs, s_diag, s_ii_inv, sr_ho,
      &sr_o, wtg
       implicit real*8(a-h,o-z)
 

--- a/src/vmc/pcm_3dgrid.f
+++ b/src/vmc/pcm_3dgrid.f
@@ -13,7 +13,7 @@ c----------------------------------------------------------------------
       use atom, only: znuc, cent, pecent, iwctype, nctype, ncent
       use insout, only: inout, inside
       use pcm_num_spl2, only: bc, wk
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use grid3d_param, only: endpt, nstep3d, origin, step3d
       implicit real*8(a-h,o-z)
 
@@ -129,7 +129,7 @@ c     Print the parameters to the output file
       end ! subroutine pcm_setup_grid
 c----------------------------------------------------------------------
       function ipcm_int_from_cart(value,iaxis)
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       implicit real*8(a-h,o-z)
 
 

--- a/src/vmc/pcm_vmc.f
+++ b/src/vmc/pcm_vmc.f
@@ -38,7 +38,7 @@
 
 c-----------------------------------------------------------------------
       subroutine pcm_fin(wcum,iblk)
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       implicit real*8(a-h,o-z)
 
       include 'pcm.h'

--- a/src/vmc/read_input.f
+++ b/src/vmc/read_input.f
@@ -62,7 +62,7 @@ c and Anthony Scemema
       use contr3, only: mode
       use contrldmc, only: iacc_rej, icross, icuspg, icut_br, icut_e, idiv_v, idmc, ipq,
      &itau_eff, nfprod, rttau, tau, taueff, tautot
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use dorb_m, only: iworbd
       use contrl_per, only: iperiodic,ibasis
       use force_analy, only: iforce_analy
@@ -120,7 +120,7 @@ c  eunit      'Hartree'
 c  nstep      number of steps per block
 c  nblk       number of blocks
 c  nblkeq     number of equilibration blocks
-c  n_conf      target number of MC configurations in dmc
+c  nconf      target number of MC configurations in dmc
 c  nconf_new  number of new MC configs. saved per processor.
 c  idump      dump restart file
 c  irstar     restart from restart file
@@ -343,7 +343,7 @@ c Parameters for blocking/start/dump
         if(index(mode,'dmc').ne.0) then
           call p2gti('blocking_dmc:nstep',nstep,1)
           call p2gti('blocking_dmc:nblk',nblk,1)
-          call p2gti('blocking_dmc:n_conf',n_conf,1)
+          call p2gti('blocking_dmc:nconf',nconf,1)
           call p2gtid('blocking_dmc:nblkeq',nblkeq,2,1)
           call p2gtid('blocking_dmc:nconf_new',nconf_new,0,1)
         endif
@@ -361,9 +361,9 @@ c Make sure that the printout is not huge
         if(index(mode,'vmc').ne.0) then
           write(6,'(''no. configurations saved ='',t30,i10)') nconf_new
          elseif(index(mode,'dmc').ne.0) then
-          write(6,'(''target walker population ='',t30,i10)') n_conf
-          if(n_conf.le.0) call fatal_error('INPUT: target population <= 0')
-          if(n_conf.gt.MWALK) call fatal_error('INPUT: target population > MWALK')
+          write(6,'(''target walker population ='',t30,i10)') nconf
+          if(nconf.le.0) call fatal_error('INPUT: target population <= 0')
+          if(nconf.gt.MWALK) call fatal_error('INPUT: target population > MWALK')
           write(6,'(''no. configurations saved ='',t31,i10)') nconf_new
         endif
 
@@ -557,7 +557,7 @@ c  ipcm=3 runs qmc with fixed polarization charges
         write(6,'(''pcm file (cavity) ='',t30,a20)') pcmfile_cavity
         write(6,'(''pcm file (chs)    ='',t30,a20)') pcmfile_chs
         write(6,'(''pcm file (chv)    ='',t30,a20)') pcmfile_chv
-        write(6,'(''pcm n_conf sampled for chv ='',t30,i10)') nscv
+        write(6,'(''pcm nconf sampled for chv ='',t30,i10)') nscv
         write(6,'(''pcm frequency for chv ='',t30,i10)') iscov
         write(6,'(''pcm epsilon_solvent ='',t30,f7.3)') eps_solv
         write(6,'(''pcm rcolv ='',t30,f7.3)') rcolv

--- a/src/vmc/store_diag_hs.f
+++ b/src/vmc/store_diag_hs.f
@@ -1,16 +1,15 @@
       subroutine store_diag_hs(nparm_p1,hii,sii)
 
       use csfs, only: ccsf, cxdet, iadet, ibdet, icxdet, ncsf, nstates
-
       use mpiconf, only: idtask, nproc
       use optwf_contrl, only: ioptci, ioptjas, ioptorb, nparm
       use optwf_func, only: ifunc_omega, omega, omega_hes
       use sa_weights, only: iweight, nweight, weights
       use sr_index, only: jelo, jelo2, jelohfj
-      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf, obs, s_diag, s_ii_inv, sr_ho,
+      use sr_mat_n, only: elocal, h_sr, jefj, jfj, jhfj, nconf_n, obs, s_diag, s_ii_inv, sr_ho,
      &sr_o, wtg, obs_tot
-      implicit real*8(a-h,o-z)
 
+      implicit real*8(a-h,o-z)
 
       include 'mpif.h'
       include 'sr.h'
@@ -18,11 +17,6 @@
       include 'force.h'
       include 'mstates.h'
       include 'optorb.h'
-
-
-
-
-
 
       dimension obs_wtg(MSTATES),obs_wtg_tot(MSTATES)
       dimension hii(MPARM),sii(MPARM)

--- a/src/vmc/verify_orbitals.f
+++ b/src/vmc/verify_orbitals.f
@@ -3,7 +3,7 @@
       use dets, only: cdet, ndet
       use optwf_contrl, only: ioptci, ioptjas, ioptorb, nparm
       use coefs, only: coef, nbasis, norb
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use dorb_m, only: iworbd
       use basis, only: zex, betaq, n1s, n2s, n2p, n3s, n3p, n3dzr, n3dx2, n3dxy, n3dxz, n3dyz,
      & n4s, n4p, n4fxxx, n4fyyy, n4fzzz, n4fxxy, n4fxxz, n4fyyx, n4fyyz,

--- a/src/vmc/vmc.f
+++ b/src/vmc/vmc.f
@@ -24,7 +24,7 @@ c and sa, pa, da asymptotic functions
       use jaspar4, only: a4, norda, nordb, nordc
       use wfsec, only: iwf, iwftype, nwftype
       use coefs, only: coef, nbasis, norb
-      use contrl, only: idump, irstar, isite, n_conf, nblk, nblkeq, nconf_new, nstep
+      use contrl, only: idump, irstar, isite, nconf, nblk, nblkeq, nconf_new, nstep
       use pseudo, only: lpot, nloc, vps, vpso
       use basis, only: zex, betaq, n1s, n2s, n2p, n3s, n3p, n3dzr, n3dx2, n3dxy, n3dxz, n3dyz,
      & n4s, n4p, n4fxxx, n4fyyy, n4fzzz, n4fxxy, n4fxxz, n4fyyx, n4fyyz,
@@ -56,7 +56,7 @@ c        nstep  = number of metropolis steps/block
 c        nblk   = number of blocks od nstep steps after the
 c                equilibrium steps
 c        nblkeq = number of equilibrium blocks
-c        n_conf  = target number of mc configurations (dmc only)
+c        nconf  = target number of mc configurations (dmc only)
 c        nconf_new = number of mc configurations generated for optim and dmc
 c        idump  =  1 dump out stuff for a restart
 c        irstar =  1 pick up stuff for a restart


### PR DESCRIPTION
This PR address this [comment](https://github.com/filippi-claudia/champ/issues/42#issuecomment-681885793) about the nconf variable. 

Two major changes:

- nconf from common block _sr_mat_n_ is changed to nconf_n.
- n_conf of common block _control_ is now back to nconf. 
