### PR TITLE
Deletion of icount_cblocks, closes #48

### DIFF
--- a/src/vmc/m_common.f90
+++ b/src/vmc/m_common.f90
@@ -2066,6 +2066,17 @@ end module forcewt
    save
  end module multimatn
 
+ module m_icount
+   !> Arguments: icount_ci, icount_orb, icount_prop 
+   integer :: icount_ci = 1 
+   integer :: icount_orb = 1
+   integer :: icount_prop = 1 
+ 
+   private   
+   public :: icount_ci, icount_orb, icount_prop 
+   save 
+end module m_icount 
+
  module numbas_mod
   !> Arguments: MRWF_PTS, MRWF
   integer, parameter :: MRWF_PTS=4000

--- a/src/vmc/optci.f
+++ b/src/vmc/optci.f
@@ -476,7 +476,7 @@ c-----------------------------------------------------------------------
       use linear_norm, only: oav
       use optwf_contrl, only: ioptci
       use ci000, only: iciprt, nciterm
-
+      use m_icount, only: icount_ci
       use method_opt, only: method
 
       implicit real*8(a-h,o-z)
@@ -484,7 +484,6 @@ c-----------------------------------------------------------------------
 
 c compute averages and print then out
 
-      common /icount_ci/ icount_ci
 
       dimension deav(MXCITERM)
       dimension oeav(MXCITERM,MXCIREDUCED),oeerr(MXCITERM,MXCIREDUCED)

--- a/src/vmc/optwf_matrix_corsamp.f
+++ b/src/vmc/optwf_matrix_corsamp.f
@@ -759,16 +759,3 @@ c 185    write(6,'(''s= '',1000d12.5)') (s(i,j),j=1,nparm+1)
 
       return
       end
-c-----------------------------------------------------------------------
-      block data optprt_count
-
-      implicit real*8(a-h,o-z)
-
-      common /icount_ci/ icount_ci
-      common /icount_orb/ icount_orb
-      common /icount_prop/ icount_prop
-      data icount_ci /1/
-      data icount_orb /1/
-      data icount_prop /1/
-
-      end

--- a/src/vmc/properties.f
+++ b/src/vmc/properties.f
@@ -133,6 +133,7 @@ c-----------------------------------------------------------------------
       use const, only: nelec
       use prp000, only: iprop, ipropprt
       use prp003, only: cc_nuc
+      use m_icount, only: icount_prop
 
       implicit real*8(a-h,o-z)
 
@@ -141,7 +142,6 @@ c-----------------------------------------------------------------------
 c compute averages and print then out
       dimension pav(MAXPROP),perr(MAXPROP)
 
-      common /icount_prop/ icount_prop
 
 c ipropprt 0 no printout
 c          1 each iteration full printout


### PR DESCRIPTION
Hi @NicoRenaud,

Thanks to @filippi-claudia 's [modification](https://github.com/filippi-claudia/champ/issues/48#issuecomment-681922291) the deletion of these three:

- icount_ci
- icount_orb
- icount_prop

is quite straightforward. Can you double-check?