### PR TITLE
two loops in the src/vmc/optwf_sr_more.f changed after profiling

### DIFF
--- a/src/vmc/optwf_sr_more.f
+++ b/src/vmc/optwf_sr_more.f
@@ -340,14 +340,29 @@ c r=a*z, i cicli doppi su n e nconf sono parallelizzati
           oz_orb=ddot(norbterm,z(nparm_jasci+1),1,sr_o(i0,iconf),1)
           aux(iconf)=(oz_jasci(iconf)+oz_orb)*wtg(iconf,istate)
         enddo
+! Three lines commented are replaced by dgemm below
+!        do i=1,nparm_jasci
+!          rloc(i)=ddot(nconf,aux(1),1,sr_o(i,1),MPARM)
+!        enddo
 
-        do i=1,nparm_jasci
-          rloc(i)=ddot(nconf,aux(1),1,sr_o(i,1),MPARM)
-        enddo
-        do i=nparm_jasci+1,n
-          i0=i+(istate-1)*norbterm
-          rloc(i)=ddot(nconf,aux(1),1,sr_o(i0,1),MPARM)
-        enddo
+        call dgemv('N', nparm_jasci, nconf, 1.0d0, sr_o(1,1), MPARM, aux(1), 1, 0.0d0, rloc(1), 1)  
+
+
+! (2) Profiling actions below
+! The following loop 2 is also replaced by dgemv. Note some additional
+! changes
+
+!        do i=nparm_jasci+1,n
+!          i0=i+(istate-1)*norbterm
+!          rloc(i)=ddot(nconf,aux(1),1,sr_o(i0,1),MPARM)
+!        enddo
+
+        i0 = nparm_jasci + 1 + (istate-1)*norbterm
+        i1 = nparm_jasci + 1 
+        call dgemv('N', n-nmparm_jasci, nconf, 1.0d0, sr_o(i0,1), MPARM, aux(1), 1, 0.0d0, rloc(i1), 1)
+
+! profiling actions ends here        
+
         call MPI_REDUCE(rloc,r_s,n,MPI_REAL8,MPI_SUM,0,MPI_COMM_WORLD,i)
         
         if(idtask.eq.0)then


### PR DESCRIPTION
Two loops are replaced by the dgemv calls after the profiling on the champ development branch. 