### PR TITLE
changes to atimes_n after profiling two loops; replacement by dgemv

### DIFF
--- a/src/vmc/optwf_sr_more.f
+++ b/src/vmc/optwf_sr_more.f
@@ -129,13 +129,24 @@ c r=a*z, i cicli doppi su n e nconf_n sono parallelizzati
           aux(iconf)=(oz_jasci(iconf)+oz_orb)*wtg(iconf,istate)
         enddo
 
-        do i=1,nparm_jasci
-          rloc(i)=ddot(nconf_n,aux(1),1,sr_o(i,1),MPARM)
-        enddo
-        do i=nparm_jasci+1,n
-          i0=i+(istate-1)*norbterm
-          rloc(i)=ddot(nconf_n,aux(1),1,sr_o(i0,1),MPARM)
-        enddo
+!       Following three lines commented and replaced by dgemv after profiling
+!        do i=1,nparm_jasci
+!          rloc(i)=ddot(nconf_n,aux(1),1,sr_o(i,1),MPARM)
+!        enddo
+
+        call dgemv('N', nparm_jasci, nconf_n, 1.0d0, sr_o(1,1), MPARM, aux(1), 1, 0.0d0, rloc(1), 1)
+
+
+!       Following code commented and replaced by dgemv after profiling
+!        do i=nparm_jasci+1,n
+!          i0=i+(istate-1)*norbterm
+!          rloc(i)=ddot(nconf_n,aux(1),1,sr_o(i0,1),MPARM)
+!        enddo
+ 
+        i0 = nparm_jasci + 1 +(istate-1)*norbterm
+        i1 = nparm_jasci + 1         
+        call dgemv('N', n - nmparm_jasci, nconf_n, 1.0d0, sr_o(i0,1), MPARM, aux(1), 1, 0.0d0, rloc(i1), 1)
+ 
         call MPI_REDUCE(rloc,r_s,n,MPI_REAL8,MPI_SUM,0,MPI_COMM_WORLD,i)
         
         if(idtask.eq.0)then


### PR DESCRIPTION
changes to atimes_n after profiling two loops using maqao. The ddot is replaced by dgemv (blas1 to blas2). 