### PR TITLE
MORB being replaced; norb_tot used for initial allocations

### DIFF
--- a/.github/workflows/build_champ_intel_fdfparser.yml
+++ b/.github/workflows/build_champ_intel_fdfparser.yml
@@ -2,9 +2,9 @@ name: Intel OneAPI Build and Testing
 
 on:
   push:
-    branches: [new-parser, merging-parser, refac-problematic]
+    branches: [remove-norb, merging-parser, refac-problematic]
   pull_request:
-    branches: [new-parser, merging-parser, refac-problematic]
+    branches: [remove-norb, merging-parser, refac-problematic]
 
 jobs:
   build_champ:

--- a/src/dmc/multideterminant_tmove.f
+++ b/src/dmc/multideterminant_tmove.f
@@ -1,6 +1,6 @@
       subroutine multideterminant_tmove(psid,iel_move)
 
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use const, only: nelec
       use atom, only: ncent
       use qua, only: nquad
@@ -22,7 +22,7 @@
       integer :: iel_move, iq, irep, ish
       integer :: j, jel, jrep, nel
       real(dp) :: detratio, dum, psid
-      real(dp), dimension(nelec, MORB) :: gmat
+      real(dp), dimension(nelec, norb_tot) :: gmat
       real(dp), parameter :: one = 1.d0
       real(dp), parameter :: half = 0.5d0
 

--- a/src/dmc/restart.f
+++ b/src/dmc/restart.f
@@ -1,6 +1,6 @@
       subroutine startr
 
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use vmc_mod, only: nrad
       use basis, only: zex, n1s, n2s, n2p, n3s, n3p, n3dzr, n3dx2, n3dxy, n3dxz, n3dyz
       use basis, only: n4s, n4p
@@ -82,7 +82,7 @@
       real(dp) :: fratio_id, hbx, taux, wdsumo_id
       real(dp) :: wq_id, wt_id, xold_dmc_id, xq_id
       real(dp) :: yq_id, zq_id
-      real(dp), dimension(nbasis, MORB) :: coefx
+      real(dp), dimension(nbasis, norb_tot) :: coefx
       real(dp), dimension(nbasis) :: zexx
       real(dp), dimension(3, ncent_tot) :: centx
       real(dp), dimension(ncent_tot) :: znucx

--- a/src/dmc/restart_gpop.f
+++ b/src/dmc/restart_gpop.f
@@ -1,6 +1,6 @@
       subroutine startr_gpop
 
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use vmc_mod, only: nrad
       use basis, only: zex, n1s, n2s, n2p, n3s, n3p, n3dzr, n3dx2, n3dxy, n3dxz, n3dyz
       use basis, only: n4s, n4p
@@ -78,7 +78,7 @@
       real(dp) :: fratio_id, hbx, taux, wq_id
       real(dp) :: wt_id, xold_dmc_id, xq_id, yq_id
       real(dp) :: zq_id
-      real(dp), dimension(nbasis, MORB) :: coefx
+      real(dp), dimension(nbasis, norb_tot) :: coefx
       real(dp), dimension(nbasis) :: zexx
       real(dp), dimension(3, ncent_tot) :: centx
       real(dp), dimension(ncent_tot) :: znucx

--- a/src/dmc/walksav_det.f
+++ b/src/dmc/walksav_det.f
@@ -6,7 +6,7 @@ c Written by Claudia Filippi
       use vmc_mod, only: MEXCIT
       use dmc_mod, only: MWALK
       use const, only: nelec
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use vmc_mod, only: nmat_dim
       use vmc_mod, only: MEXCIT
       use dmc_mod, only: MWALK
@@ -53,11 +53,11 @@ c Written by Claudia Filippi
       dimension istatus(MPI_STATUS_SIZE)
       dimension irequest_array(MPI_STATUS_SIZE)
 
-      if(.not.allocated(aaw)) allocate(aaw(nelec,MORB,MWALK,2))
+      if(.not.allocated(aaw)) allocate(aaw(nelec,norb_tot,MWALK,2))
       if(.not.allocated(wfmatw)) allocate(wfmatw(MEXCIT**2,ndet,MWALK,2))
-      if(.not.allocated(ymatw)) allocate(ymatw(MORB,nelec,MWALK,2,MSTATES))
-      if(.not.allocated(orbw)) allocate(orbw(nelec,MORB,MWALK))
-      if(.not.allocated(dorbw)) allocate(dorbw(3,nelec,MORB,MWALK))
+      if(.not.allocated(ymatw)) allocate(ymatw(norb_tot,nelec,MWALK,2,MSTATES))
+      if(.not.allocated(orbw)) allocate(orbw(nelec,norb_tot,MWALK))
+      if(.not.allocated(dorbw)) allocate(dorbw(3,nelec,norb_tot,MWALK))
 
       if(.not.allocated(krefw)) allocate(krefw(MWALK))
       if(.not.allocated(slmuiw)) allocate(slmuiw(nmat_dim,MWALK))
@@ -241,7 +241,7 @@ c Written by Claudia Filippi
       do 150 istate=1,nstates
         do 150 iab=1,2
         itag=itag+1
- 150    call mpi_isend(ymatw(1,1,nwalk,iab,istate),MORB*nelec,mpi_double_precision
+ 150    call mpi_isend(ymatw(1,1,nwalk,iab,istate),norb_tot*nelec,mpi_double_precision
      &   ,irecv,itag,MPI_COMM_WORLD,irequest,ierr)
 
       do 160 iab=1,2
@@ -294,7 +294,7 @@ c Written by Claudia Filippi
       do 250 istate=1,nstates
         do 250 iab=1,2
         itag=itag+1
- 250    call mpi_recv(ymatw(1,1,nwalk,iab,istate),MORB*nelec,mpi_double_precision
+ 250    call mpi_recv(ymatw(1,1,nwalk,iab,istate),norb_tot*nelec,mpi_double_precision
      &   ,isend,itag,MPI_COMM_WORLD,istatus,ierr)
 
       do 260 iab=1,2
@@ -307,9 +307,9 @@ c Written by Claudia Filippi
         endif
  260  continue
 
-      call mpi_recv(orbw(1,1,nwalk),nelec*morb,mpi_double_precision
+      call mpi_recv(orbw(1,1,nwalk),nelec*norb_tot,mpi_double_precision
      &  ,isend,itag+1,MPI_COMM_WORLD,istatus,ierr)
-      call mpi_recv(dorbw(1,1,1,nwalk),3*nelec*morb,mpi_double_precision
+      call mpi_recv(dorbw(1,1,1,nwalk),3*nelec*norb_tot,mpi_double_precision
      &  ,isend,itag+2,MPI_COMM_WORLD,istatus,ierr)
       itag=itag+2
 

--- a/src/vmc/3dgrid_orbitals.f
+++ b/src/vmc/3dgrid_orbitals.f
@@ -413,8 +413,8 @@ c Lagrange interpolation routines
       use grid_lagrange_mod, only: LAGSTART, LAGEND
       use grid_lagrange_mod, only: orb_num_lag
       use grid_mod, only: cart_from_int
-      use vmc_mod, only: MORB
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
+      use vmc_mod, only: norb_tot
       use atom, only: cent, ncent
       use wfsec, only: iwf
       use grid3d_param, only: nstep3d, endpt, origin
@@ -433,7 +433,7 @@ c Lagrange interpolation routines
       integer :: j, m, memory
       real(dp) :: value, value2
       real(dp), dimension(3) :: r
-      real(dp), dimension(MORB) :: f
+      real(dp), dimension(norb_tot) :: f
 
 
 
@@ -619,7 +619,7 @@ c
       use grid_lagrange_mod, only: LAGMAX, LAGSTART, LAGEND
       use grid_lagrange_mod, only: orb_num_lag
       use grid_mod, only: cart_from_int
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use insout, only: inout, inside
       use coefs, only: norb
       use grid3d_param, only: nstep3d, step3d
@@ -645,7 +645,7 @@ c
       real(dp) :: orb1, orb2
       real(dp), dimension(3) :: r
       real(dp), dimension(3) :: dr
-      real(dp), dimension(nelec,MORB) :: orb
+      real(dp), dimension(nelec,norb_tot) :: orb
       real(dp), dimension(LAGSTART:LAGEND) :: xi
 
 
@@ -718,7 +718,7 @@ c
       use grid_lagrange_mod, only: LAGMAX, LAGSTART, LAGEND
       use grid_lagrange_mod, only: orb_num_lag
       use grid_mod, only: cart_from_int
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use insout, only: inout, inside
       use coefs, only: norb
       use grid3d_param, only: nstep3d, step3d
@@ -744,7 +744,7 @@ c
       real(dp) :: orb1, orb2
       real(dp), dimension(3) :: r
       real(dp), dimension(3) :: dr
-      real(dp), dimension(3,nelec,MORB) :: orb
+      real(dp), dimension(3,nelec,norb_tot) :: orb
       real(dp), dimension(LAGSTART:LAGEND) :: xi
 
 
@@ -818,7 +818,7 @@ c
       use grid_lagrange_mod, only: LAGMAX, LAGSTART, LAGEND
       use grid_lagrange_mod, only: orb_num_lag
       use grid_mod, only: cart_from_int
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use insout, only: inout, inside
       use coefs, only: norb
       use grid3d_param, only: nstep3d, step3d
@@ -843,7 +843,7 @@ c
       real(dp) :: orb1, orb2
       real(dp), dimension(3) :: r
       real(dp), dimension(3) :: dr
-      real(dp), dimension(MORB) :: orb
+      real(dp), dimension(norb_tot) :: orb
       real(dp), dimension(LAGSTART:LAGEND) :: xi
 
 
@@ -916,7 +916,7 @@ c
       use grid_lagrange_mod, only: LAGMAX, LAGSTART, LAGEND
       use grid_lagrange_mod, only: orb_num_lag
       use grid_mod, only: cart_from_int
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use insout, only: inout, inside
       use coefs, only: norb
       use grid3d_param, only: nstep3d, step3d
@@ -941,7 +941,7 @@ c
       real(dp) :: orb1, orb2
       real(dp), dimension(3) :: r
       real(dp), dimension(3) :: dr
-      real(dp), dimension(3,MORB) :: orb
+      real(dp), dimension(3,norb_tot) :: orb
       real(dp), dimension(LAGSTART:LAGEND) :: xi
 
 

--- a/src/vmc/bxmatrices.f
+++ b/src/vmc/bxmatrices.f
@@ -1,6 +1,6 @@
       subroutine bxmatrix(kref,xmatu,xmatd,b)
 
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use elec, only: ndn, nup
       use dorb_m, only: iworbd
       use slater, only: slmi
@@ -12,7 +12,7 @@
       integer :: i, iab, iel, ish, j
       integer :: kref, nel
 
-      real(dp), dimension(MORB, nelec) :: b
+      real(dp), dimension(norb_tot, nelec) :: b
       real(dp), dimension(nelec**2, 2) :: btemp
       real(dp), dimension(nelec**2) :: xmatu
       real(dp), dimension(nelec**2) :: xmatd

--- a/src/vmc/determinante.f
+++ b/src/vmc/determinante.f
@@ -70,7 +70,7 @@ c-----------------------------------------------------------------------
       subroutine compute_determinante_grad(iel,psig,psid,vd,iflag_move)
 
       use precision_kinds, only: dp
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use csfs, only: nstates
       use elec, only: nup
       use multidet, only: kref
@@ -99,16 +99,16 @@ c-----------------------------------------------------------------------
       real(dp), dimension(3) :: vd
       real(dp), dimension(3) :: vref
       real(dp), dimension(3) :: vd_s
-      real(dp), dimension(3, MORB) :: dorb_tmp
+      real(dp), dimension(3, norb) :: dorb_tmp
 
       ! NR : ymat_tmp was not saved ....
       ! it has the save keywoprd in the dev branch ...
-      ! real(dp), dimension(MORB, nelec) :: ymat_tmp
+      ! real(dp), dimension(norb_tot, nelec) :: ymat_tmp
 
       real(dp), allocatable, save :: ymat_tmp(:,:)
       if (.not. allocated(ymat_tmp)) then
-        ! CF : ymat_tmp(MORB,nelec) max value of # orb
-        allocate(ymat_tmp(MORB,nelec))
+        ! CF : ymat_tmp(norb_tot,nelec) max value of # orb
+        allocate(ymat_tmp(norb_tot,nelec))
       endif
 
       ! save ymat_tmp
@@ -269,7 +269,7 @@ c-----------------------------------------------------------------------
       subroutine determinante_ref_grad(iel,slmi,dorb,ddx_ref)
 
       use precision_kinds, only: dp
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use vmc_mod, only: nmat_dim
       use elec, only: ndn, nup
       use multidet, only: kref
@@ -281,7 +281,7 @@ c-----------------------------------------------------------------------
       integer :: nel
 
       real(dp), dimension(nmat_dim) :: slmi
-      real(dp), dimension(3, MORB) :: dorb
+      real(dp), dimension(3, norb_tot) :: dorb
       real(dp), dimension(3) :: ddx_ref
 
 

--- a/src/vmc/dumper_more.f
+++ b/src/vmc/dumper_more.f
@@ -2,7 +2,7 @@
 c Written by Cyrus Umrigar, modified by Claudia Filippi
 c routine to pick up and dump everything needed to restart
 c job where it left off
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use vmc_mod, only: nrad
       use atom, only: znuc, cent, pecent, iwctype, nctype, ncent, ncent_tot, nctype_tot
       use mstates_mod, only: MSTATES
@@ -80,7 +80,7 @@ c job where it left off
       real(dp) :: ajacob, cjas1x, cjas2x, deltarx
       real(dp) :: deltatx, deltax, dist, distance_node
       real(dp) :: pecx, psidg, rnorm_nodes
-      real(dp), dimension(nbasis,MORB) :: coefx
+      real(dp), dimension(nbasis,norb_tot) :: coefx
       real(dp), dimension(nbasis) :: zexx
       real(dp), dimension(3,ncent_tot) :: centx
       real(dp), dimension(nctype_tot) :: znucx

--- a/src/vmc/force_analytic.f
+++ b/src/vmc/force_analytic.f
@@ -30,7 +30,7 @@ c     write(ounit,*) 'da_psi',((da_psi(k,ic),k=1,3),ic=1,ncent)
 c-----------------------------------------------------------------------
       subroutine compute_da_psi(psid,da_psi_ref)
 
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use atom, only: ncent, ncent_tot
       use const, only: nelec
       use da_energy_now, only: da_psi
@@ -51,9 +51,9 @@ c-----------------------------------------------------------------------
       integer :: irep, ish, j, jorb
       integer :: jrep, k, nel
       real(dp) :: c800, psid, trace
-      real(dp), dimension(MORB, nelec) :: b_a
+      real(dp), dimension(norb_tot, nelec) :: b_a
       real(dp), dimension(nelec*nelec) :: b_kref
-      real(dp), dimension(nelec, MORB) :: tildem_a
+      real(dp), dimension(nelec, norb_tot) :: tildem_a
       real(dp), dimension(3, ncent_tot) :: da_psi_ref
 
       do 400 ic=1,ncent

--- a/src/vmc/m_coefs.f90
+++ b/src/vmc/m_coefs.f90
@@ -6,7 +6,7 @@ module coefs
 
     implicit none
 
-    real(dp), dimension(:, :, :), allocatable :: coef !(MBASIS,MORB,MWF)
+    real(dp), dimension(:, :, :), allocatable :: coef !(MBASIS,norb_tot,MWF)
     integer :: nbasis
     integer :: norb
     integer :: next_max
@@ -20,8 +20,8 @@ contains
     ! subroutine allocate_coefs()
     !     use force_mod, only: MWF
     !     use precision_kinds, only: dp
-    !     use vmc_mod, only: MORB, MBASIS
-    !     if (.not. allocated(coef)) allocate (coef(MBASIS, MORB, MWF))
+    !     use vmc_mod, only: norb_tot, MBASIS
+    !     if (.not. allocated(coef)) allocate (coef(MBASIS, norb_tot, MWF))
     ! end subroutine allocate_coefs
 
     subroutine deallocate_coefs()

--- a/src/vmc/m_common.f90
+++ b/src/vmc/m_common.f90
@@ -2,11 +2,11 @@ module b_tmove
     !> Arguments: b_t, iskip
     use pseudo_mod, only: MPS_QUAD
     use precision_kinds, only: dp
-    use vmc_mod, only: MORB
+    use vmc_mod, only: norb_tot
 
     implicit none
 
-    real(dp), dimension(:, :, :, :), allocatable :: b_t !(MORB,MPS_QUAD,MCENT,MELEC)
+    real(dp), dimension(:, :, :, :), allocatable :: b_t !(norb_tot,MPS_QUAD,MCENT,MELEC)
     integer, dimension(:, :), allocatable :: iskip !(MELEC,MCENT)
 
     private
@@ -18,8 +18,8 @@ contains
         use const, only: nelec
         use atom, only: ncent_tot
         use pseudo_mod, only: MPS_QUAD
-        use vmc_mod, only: MORB
-        if (.not. allocated(b_t)) allocate (b_t(MORB, MPS_QUAD, ncent_tot, nelec))
+        use vmc_mod, only: norb_tot
+        if (.not. allocated(b_t)) allocate (b_t(norb_tot, MPS_QUAD, ncent_tot, nelec))
         if (.not. allocated(iskip)) allocate (iskip(nelec, ncent_tot))
     end subroutine allocate_b_tmove
 
@@ -33,21 +33,21 @@ end module b_tmove
 module Bloc
     !> Arguments: b, tildem, xmat
     use precision_kinds, only: dp
-    use vmc_mod, only: MORB
+    use vmc_mod, only: norb_tot
     use optjas, only: MPARMJ
 
     implicit none
 
-    real(dp), dimension(:, :), allocatable :: b !(MORB,MELEC)
-    real(dp), dimension(:, :, :), allocatable :: tildem !(MELEC,MORB,2)
+    real(dp), dimension(:, :), allocatable :: b !(norb_tot,MELEC)
+    real(dp), dimension(:, :, :), allocatable :: tildem !(MELEC,norb_tot,2)
     real(dp), dimension(:, :), allocatable :: xmat !(MELEC**2,2)
 
     !> Former Bloc_da
-    real(dp), dimension(:, :, :, :), allocatable :: b_da !(3,MELEC,MORB,MCENT)
-    real(dp), dimension(:, :, :, :), allocatable :: db !(3,MELEC,MORB,MCENT)
+    real(dp), dimension(:, :, :, :), allocatable :: b_da !(3,MELEC,norb_tot,MCENT)
+    real(dp), dimension(:, :, :, :), allocatable :: db !(3,MELEC,norb_tot,MCENT)
 
     !> former Bloc_dj
-    real(dp), dimension(:, :, :), allocatable :: b_dj !(MORB,MELEC,MPARMJ)
+    real(dp), dimension(:, :, :), allocatable :: b_dj !(norb_tot,MELEC,MPARMJ)
 
     private
     public :: b, tildem, xmat
@@ -60,14 +60,14 @@ contains
         use const, only: nelec
         use coefs, only: norb
         use atom, only: ncent_tot
-        use vmc_mod, only: MORB
+        use vmc_mod, only: norb_tot
         use optjas, only: MPARMJ
-        if (.not. allocated(b)) allocate (b(MORB, nelec))
-        if (.not. allocated(tildem)) allocate (tildem(nelec, MORB, 2))
+        if (.not. allocated(b)) allocate (b(norb_tot, nelec))
+        if (.not. allocated(tildem)) allocate (tildem(nelec, norb_tot, 2))
         if (.not. allocated(xmat)) allocate (xmat(nelec**2, 2))
-        if (.not. allocated(b_da)) allocate (b_da(3, nelec, MORB, ncent_tot))
-        if (.not. allocated(db)) allocate (db(3, nelec, MORB, ncent_tot))
-        if (.not. allocated(b_dj)) allocate (b_dj(MORB, nelec, MPARMJ))
+        if (.not. allocated(b_da)) allocate (b_da(3, nelec, norb_tot, ncent_tot))
+        if (.not. allocated(db)) allocate (db(3, nelec, norb_tot, ncent_tot))
+        if (.not. allocated(b_dj)) allocate (b_dj(norb_tot, nelec, MPARMJ))
     end subroutine allocate_Bloc
 
     subroutine deallocate_Bloc()
@@ -480,7 +480,7 @@ module multimat
 
     implicit none
 
-    real(dp), dimension(:, :, :), allocatable :: aa !(MELEC,MORB,2)
+    real(dp), dimension(:, :, :), allocatable :: aa !(MELEC,norb_tot,2)
     real(dp), dimension(:, :, :), allocatable :: wfmat !(MEXCIT**2,MDET,2)
 
     private
@@ -492,9 +492,9 @@ contains
         use const, only: nelec
         use dets, only: ndet
         use coefs, only: norb
-        use vmc_mod, only: MORB
+        use vmc_mod, only: norb_tot
         use vmc_mod, only: MEXCIT
-        if (.not. allocated(aa)) allocate (aa(nelec, MORB, 2))
+        if (.not. allocated(aa)) allocate (aa(nelec, norb_tot, 2))
         if (.not. allocated(wfmat)) allocate (wfmat(MEXCIT**2, ndet, 2))
     end subroutine allocate_multimat
 
@@ -511,7 +511,7 @@ module multimatn
 
     implicit none
 
-    real(dp), dimension(:, :), allocatable :: aan !(MELEC,MORB)
+    real(dp), dimension(:, :), allocatable :: aan !(MELEC,norb_tot)
     real(dp), dimension(:, :), allocatable :: wfmatn !(MEXCIT**2,MDET)
 
     private
@@ -522,9 +522,9 @@ contains
     subroutine allocate_multimatn()
         use const, only: nelec
         use dets, only: ndet
-        use vmc_mod, only: MORB
+        use vmc_mod, only: norb_tot
         use vmc_mod, only: MEXCIT
-        if (.not. allocated(aan)) allocate (aan(nelec, MORB))
+        if (.not. allocated(aan)) allocate (aan(nelec, norb_tot))
         if (.not. allocated(wfmatn)) allocate (wfmatn(MEXCIT**2, ndet))
     end subroutine allocate_multimatn
 
@@ -570,14 +570,14 @@ end module multislater
 module multislatern
     !> Arguments: ddorbn, detn, dorbn, orbn
     use precision_kinds, only: dp
-    use vmc_mod, only: MORB
+    use vmc_mod, only: norb_tot
 
     implicit none
 
-    real(dp), dimension(:), allocatable :: ddorbn !(MORB)
+    real(dp), dimension(:), allocatable :: ddorbn !(norb_tot)
     real(dp), dimension(:), allocatable :: detn !(MDET)
-    real(dp), dimension(:, :), allocatable :: dorbn !(3,MORB)
-    real(dp), dimension(:), allocatable :: orbn !(MORB)
+    real(dp), dimension(:, :), allocatable :: dorbn !(3,norb_tot)
+    real(dp), dimension(:), allocatable :: orbn !(norb_tot)
     private
 
     public ::  ddorbn, detn, dorbn, orbn
@@ -587,11 +587,11 @@ contains
     subroutine allocate_multislatern()
         use dets, only: ndet
         use coefs, only: norb
-        use vmc_mod, only: MORB
-        if (.not. allocated(ddorbn)) allocate (ddorbn(MORB))
+        use vmc_mod, only: norb_tot
+        if (.not. allocated(ddorbn)) allocate (ddorbn(norb_tot))
         if (.not. allocated(detn)) allocate (detn(ndet))
-        if (.not. allocated(dorbn)) allocate (dorbn(3, MORB))
-        if (.not. allocated(orbn)) allocate (orbn(MORB))
+        if (.not. allocated(dorbn)) allocate (dorbn(3, norb_tot))
+        if (.not. allocated(orbn)) allocate (orbn(norb_tot))
     end subroutine allocate_multislatern
 
     subroutine deallocate_multislatern()
@@ -637,15 +637,15 @@ end module ncusp
 module orbval
     !> Arguments: ddorb, dorb, nadorb, ndetorb, orb
     use precision_kinds, only: dp
-    use vmc_mod, only: MORB
+    use vmc_mod, only: norb_tot
 
     implicit none
 
-    real(dp), dimension(:, :), allocatable :: ddorb !(MELEC,MORB)
-    real(dp), dimension(:, :, :), allocatable :: dorb !(3,MELEC,MORB)
+    real(dp), dimension(:, :), allocatable :: ddorb !(MELEC,norb_tot)
+    real(dp), dimension(:, :, :), allocatable :: dorb !(3,MELEC,norb_tot)
     integer :: nadorb
     integer :: ndetorb
-    real(dp), dimension(:, :), allocatable :: orb !(MELEC,MORB)
+    real(dp), dimension(:, :), allocatable :: orb !(MELEC,norb_tot)
 
     private
     public :: ddorb, dorb, nadorb, ndetorb, orb
@@ -656,9 +656,9 @@ contains
         use const, only: nelec
         use coefs, only: norb
         use precision_kinds, only: dp
-        if (.not. allocated(ddorb)) allocate (ddorb(nelec, MORB))
-        if (.not. allocated(dorb)) allocate (dorb(3, nelec, MORB))
-        if (.not. allocated(orb)) allocate (orb(nelec, MORB))
+        if (.not. allocated(ddorb)) allocate (ddorb(nelec, norb_tot))
+        if (.not. allocated(dorb)) allocate (dorb(3, nelec, norb_tot))
+        if (.not. allocated(orb)) allocate (orb(nelec, norb_tot))
     end subroutine allocate_orbval
 
     subroutine deallocate_orbval()
@@ -807,12 +807,12 @@ end module scale_more
 module scratch
     !> Arguments: denergy_det, dtildem
     use precision_kinds, only: dp
-    use vmc_mod, only: MORB
+    use vmc_mod, only: norb_tot
 
     implicit none
 
     real(dp), dimension(:, :), allocatable :: denergy_det !(MDET,2)
-    real(dp), dimension(:, :, :), allocatable :: dtildem !(MELEC,MORB,2)
+    real(dp), dimension(:, :, :), allocatable :: dtildem !(MELEC,norb_tot,2)
 
     private
     public :: denergy_det, dtildem
@@ -822,9 +822,9 @@ contains
     subroutine allocate_scratch()
         use const, only: nelec
         use dets, only: ndet
-        use vmc_mod, only: MORB
+        use vmc_mod, only: norb_tot
         if (.not. allocated(denergy_det)) allocate (denergy_det(ndet, 2))
-        if (.not. allocated(dtildem)) allocate (dtildem(nelec, MORB, 2))
+        if (.not. allocated(dtildem)) allocate (dtildem(nelec, norb_tot, 2))
     end subroutine allocate_scratch
 
     subroutine deallocate_scratch()
@@ -991,13 +991,13 @@ end module velocity_jastrow
 module ycompact
     !> Arguments: dymat, ymat
     use precision_kinds, only: dp
-    use vmc_mod, only: MORB
+    use vmc_mod, only: norb_tot
     use mstates_mod, only: MSTATES
 
     implicit none
 
-    real(dp), dimension(:, :, :, :), allocatable :: dymat !(MORB,MELEC,2,MSTATES)
-    real(dp), dimension(:, :, :, :), allocatable :: ymat !(MORB,MELEC,2,MSTATES)
+    real(dp), dimension(:, :, :, :), allocatable :: dymat !(norb_tot,MELEC,2,MSTATES)
+    real(dp), dimension(:, :, :, :), allocatable :: ymat !(norb_tot,MELEC,2,MSTATES)
 
     private
     public :: dymat, ymat
@@ -1006,10 +1006,10 @@ module ycompact
 contains
     subroutine allocate_ycompact()
         use const, only: nelec
-        use vmc_mod, only: MORB
+        use vmc_mod, only: norb_tot
         use mstates_mod, only: MSTATES
-        if (.not. allocated(dymat)) allocate (dymat(MORB, nelec, 2, MSTATES))
-        if (.not. allocated(ymat)) allocate (ymat(MORB, nelec, 2, MSTATES))
+        if (.not. allocated(dymat)) allocate (dymat(norb_tot, nelec, 2, MSTATES))
+        if (.not. allocated(ymat)) allocate (ymat(norb_tot, nelec, 2, MSTATES))
     end subroutine allocate_ycompact
 
     subroutine deallocate_ycompact()
@@ -1022,12 +1022,12 @@ end module ycompact
 module ycompactn
     !> Arguments: ymatn
     use precision_kinds, only: dp
-    use vmc_mod, only: MORB
+    use vmc_mod, only: norb_tot
     use mstates_mod, only: MSTATES
 
     implicit none
 
-    real(dp), dimension(:, :, :), allocatable :: ymatn !(MORB,MELEC,MSTATES)
+    real(dp), dimension(:, :, :), allocatable :: ymatn !(norb_tot,MELEC,MSTATES)
 
     private
     public :: ymatn
@@ -1036,9 +1036,9 @@ module ycompactn
 contains
     subroutine allocate_ycompactn()
         use const, only: nelec
-        use vmc_mod, only: MORB
+        use vmc_mod, only: norb_tot
         use mstates_mod, only: MSTATES
-        if (.not. allocated(ymatn)) allocate (ymatn(MORB, nelec, MSTATES))
+        if (.not. allocated(ymatn)) allocate (ymatn(norb_tot, nelec, MSTATES))
     end subroutine allocate_ycompactn
 
     subroutine deallocate_ycompactn()
@@ -1050,15 +1050,15 @@ end module ycompactn
 module zcompact
     !> Arguments: aaz, dzmat, emz, zmat
     use precision_kinds, only: dp
-    use vmc_mod, only: MORB
+    use vmc_mod, only: norb_tot
     use mstates_mod, only: MSTATES
 
     implicit none
 
     real(dp), dimension(:, :, :, :), allocatable :: aaz !(MELEC,MELEC,2,MSTATES)
-    real(dp), dimension(:, :, :, :), allocatable :: dzmat !(MORB,MELEC,2,MSTATES)
+    real(dp), dimension(:, :, :, :), allocatable :: dzmat !(norb_tot,MELEC,2,MSTATES)
     real(dp), dimension(:, :, :, :), allocatable :: emz !(MELEC,MELEC,2,MSTATES)
-    real(dp), dimension(:, :, :, :), allocatable :: zmat !(MORB,MELEC,2,MSTATES)
+    real(dp), dimension(:, :, :, :), allocatable :: zmat !(norb_tot,MELEC,2,MSTATES)
 
     private
     public :: aaz, dzmat, emz, zmat
@@ -1067,12 +1067,12 @@ module zcompact
 contains
     subroutine allocate_zcompact()
         use const, only: nelec
-        use vmc_mod, only: MORB
+        use vmc_mod, only: norb_tot
         use mstates_mod, only: MSTATES
         if (.not. allocated(aaz)) allocate (aaz(nelec, nelec, 2, MSTATES))
-        if (.not. allocated(dzmat)) allocate (dzmat(MORB, nelec, 2, MSTATES))
+        if (.not. allocated(dzmat)) allocate (dzmat(norb_tot, nelec, 2, MSTATES))
         if (.not. allocated(emz)) allocate (emz(nelec, nelec, 2, MSTATES))
-        if (.not. allocated(zmat)) allocate (zmat(MORB, nelec, 2, MSTATES))
+        if (.not. allocated(zmat)) allocate (zmat(norb_tot, nelec, 2, MSTATES))
     end subroutine allocate_zcompact
 
     subroutine deallocate_zcompact()

--- a/src/vmc/m_deriv.f90
+++ b/src/vmc/m_deriv.f90
@@ -68,13 +68,13 @@ end module da_jastrow4val
 module da_orbval
     !> Arguments: da_d2orb, da_dorb, da_orb
     use precision_kinds, only: dp
-    use vmc_mod, only: MORB
+    use vmc_mod, only: norb_tot
 
     implicit none
 
-    real(dp), dimension(:, :, :, :), allocatable :: da_d2orb !(3, MELEC, MORB, MCENT)
-    real(dp), dimension(:, :, :, :, :), allocatable :: da_dorb !(3, 3, MELEC, MORB, MCENT)
-    real(dp), dimension(:, :, :, :), allocatable :: da_orb !(3, MELEC, MORB, MCENT)
+    real(dp), dimension(:, :, :, :), allocatable :: da_d2orb !(3, MELEC, norb_tot, MCENT)
+    real(dp), dimension(:, :, :, :, :), allocatable :: da_dorb !(3, 3, MELEC, norb_tot, MCENT)
+    real(dp), dimension(:, :, :, :), allocatable :: da_orb !(3, MELEC, norb_tot, MCENT)
 
     private
     public   ::  da_d2orb, da_dorb, da_orb
@@ -84,10 +84,10 @@ contains
     subroutine allocate_da_orbval()
         use const, only: nelec
         use atom, only: ncent_tot
-        use vmc_mod, only: MORB
-        if (.not. allocated(da_d2orb)) allocate (da_d2orb(3, nelec, MORB, ncent_tot))
-        if (.not. allocated(da_dorb)) allocate (da_dorb(3, 3, nelec, MORB, ncent_tot))
-        if (.not. allocated(da_orb)) allocate (da_orb(3, nelec, MORB, ncent_tot))
+        use vmc_mod, only: norb_tot
+        if (.not. allocated(da_d2orb)) allocate (da_d2orb(3, nelec, norb_tot, ncent_tot))
+        if (.not. allocated(da_dorb)) allocate (da_dorb(3, 3, nelec, norb_tot, ncent_tot))
+        if (.not. allocated(da_orb)) allocate (da_orb(3, nelec, norb_tot, ncent_tot))
     end subroutine allocate_da_orbval
 
     subroutine deallocate_da_orbval()

--- a/src/vmc/m_ewald.f90
+++ b/src/vmc/m_ewald.f90
@@ -88,7 +88,7 @@ module ewald_mod
      use ewald_mod, only: NGNORM_BIGX, NGVEC_BIGX
      use ewald_mod, only: NGNORM_SIM_BIGX, NGVEC_SIM_BIGX
      use precision_kinds, only: dp
-     use vmc_mod, only: MORB
+     use vmc_mod, only: norb_tot
 
      implicit none
 
@@ -109,7 +109,7 @@ module ewald_mod
      integer, dimension(:), allocatable :: igmult_sim !(NGNORM_SIM_BIGX)
      integer, dimension(:, :), allocatable :: igvec !(3,NGVEC_BIGX)
      integer, dimension(:, :), allocatable :: igvec_sim !(3,NGVEC_SIM_BIGX)
-     integer, dimension(:), allocatable :: ireal_imag !(MORB)
+     integer, dimension(:), allocatable :: ireal_imag !(norb_tot)
      integer :: isrange
      integer, dimension(:), allocatable :: k_inv !(IVOL_RATIO)
      integer, dimension(:, :), allocatable :: kvec !(3,IVOL_RATIO)
@@ -156,7 +156,7 @@ module ewald_mod
          use ewald_mod, only: IVOL_RATIO
          use ewald_mod, only: NGNORM_BIGX, NGVEC_BIGX
          use ewald_mod, only: NGNORM_SIM_BIGX, NGVEC_SIM_BIGX
-         use vmc_mod, only: MORB
+         use vmc_mod, only: norb_tot
          if (.not. allocated(glatt)) allocate (glatt(3, 3))
          if (.not. allocated(glatt_inv)) allocate (glatt_inv(3, 3))
          if (.not. allocated(glatt_sim)) allocate (glatt_sim(3, 3))
@@ -168,7 +168,7 @@ module ewald_mod
          if (.not. allocated(igmult_sim)) allocate (igmult_sim(NGNORM_SIM_BIGX))
          if (.not. allocated(igvec)) allocate (igvec(3, NGVEC_BIGX))
          if (.not. allocated(igvec_sim)) allocate (igvec_sim(3, NGVEC_SIM_BIGX))
-         if (.not. allocated(ireal_imag)) allocate (ireal_imag(MORB))
+         if (.not. allocated(ireal_imag)) allocate (ireal_imag(norb_tot))
          if (.not. allocated(k_inv)) allocate (k_inv(IVOL_RATIO))
          if (.not. allocated(kvec)) allocate (kvec(3, IVOL_RATIO))
          if (.not. allocated(nband)) allocate (nband(IVOL_RATIO))
@@ -217,18 +217,18 @@ module ewald_mod
      use ewald_mod, only: IVOL_RATIO
      use ewald_mod, only: NGVECX
      use precision_kinds, only: dp
-     use vmc_mod, only: MORB
+     use vmc_mod, only: norb_tot
 
      implicit none
 
-     real(dp), dimension(:, :), allocatable :: c_im !(NGVECX,MORB)
-     real(dp), dimension(:, :), allocatable :: c_ip !(NGVECX,MORB)
-     real(dp), dimension(:, :), allocatable :: c_rm !(NGVECX,MORB)
-     real(dp), dimension(:, :), allocatable :: c_rp !(NGVECX,MORB)
+     real(dp), dimension(:, :), allocatable :: c_im !(NGVECX,norb_tot)
+     real(dp), dimension(:, :), allocatable :: c_ip !(NGVECX,norb_tot)
+     real(dp), dimension(:, :), allocatable :: c_rm !(NGVECX,norb_tot)
+     real(dp), dimension(:, :), allocatable :: c_rp !(NGVECX,norb_tot)
      integer :: icmplx
-     integer, dimension(:, :), allocatable :: isortg !(NGVECX,MORB)
+     integer, dimension(:, :), allocatable :: isortg !(NGVECX,norb_tot)
      integer, dimension(:), allocatable :: isortk !(IVOL_RATIO)
-     integer, dimension(:), allocatable :: ngorb !(MORB)
+     integer, dimension(:), allocatable :: ngorb !(norb_tot)
 
      private
      public :: c_im, c_ip, c_rm, c_rp, icmplx, isortg, isortk, ngorb
@@ -238,14 +238,14 @@ module ewald_mod
      subroutine allocate_pworbital()
          use ewald_mod, only: IVOL_RATIO
          use ewald_mod, only: NGVECX
-         use vmc_mod, only: MORB
-         if (.not. allocated(c_im)) allocate (c_im(NGVECX, MORB))
-         if (.not. allocated(c_ip)) allocate (c_ip(NGVECX, MORB))
-         if (.not. allocated(c_rm)) allocate (c_rm(NGVECX, MORB))
-         if (.not. allocated(c_rp)) allocate (c_rp(NGVECX, MORB))
-         if (.not. allocated(isortg)) allocate (isortg(NGVECX, MORB))
+         use vmc_mod, only: norb_tot
+         if (.not. allocated(c_im)) allocate (c_im(NGVECX, norb_tot))
+         if (.not. allocated(c_ip)) allocate (c_ip(NGVECX, norb_tot))
+         if (.not. allocated(c_rm)) allocate (c_rm(NGVECX, norb_tot))
+         if (.not. allocated(c_rp)) allocate (c_rp(NGVECX, norb_tot))
+         if (.not. allocated(isortg)) allocate (isortg(NGVECX, norb_tot))
          if (.not. allocated(isortk)) allocate (isortk(IVOL_RATIO))
-         if (.not. allocated(ngorb)) allocate (ngorb(MORB))
+         if (.not. allocated(ngorb)) allocate (ngorb(norb_tot))
      end subroutine allocate_pworbital
 
      subroutine deallocate_pworbital()

--- a/src/vmc/m_optorb.f90
+++ b/src/vmc/m_optorb.f90
@@ -352,11 +352,11 @@ end module orb_mat_033
 module optorb
     !> Arguments: dmat_diag, irrep, orb_energy
     use precision_kinds, only: dp
-    use vmc_mod, only: MORB
+    use vmc_mod, only: norb_tot
 
-    real(dp), dimension(:), allocatable :: dmat_diag !(MORB)
-    integer, dimension(:), allocatable :: irrep !(MORB)
-    real(dp), dimension(:), allocatable :: orb_energy !(MORB)
+    real(dp), dimension(:), allocatable :: dmat_diag !(norb_tot)
+    integer, dimension(:), allocatable :: irrep !(norb_tot)
+    real(dp), dimension(:), allocatable :: orb_energy !(norb_tot)
 
     private
     public :: dmat_diag, irrep, orb_energy
@@ -364,10 +364,10 @@ module optorb
     save
 contains
     subroutine allocate_optorb()
-        use vmc_mod, only: MORB
-        if (.not. allocated(dmat_diag)) allocate (dmat_diag(MORB))
-        ! if (.not. allocated(irrep)) allocate (irrep(MORB))
-        ! if (.not. allocated(orb_energy)) allocate (orb_energy(MORB))
+        use vmc_mod, only: norb_tot
+        if (.not. allocated(dmat_diag)) allocate (dmat_diag(norb_tot))
+        ! if (.not. allocated(irrep)) allocate (irrep(norb_tot))
+        ! if (.not. allocated(orb_energy)) allocate (orb_energy(norb_tot))
     end subroutine allocate_optorb
 
     subroutine deallocate_optorb()
@@ -419,9 +419,9 @@ end module optorb_cblock
 
 module optorb_mix
     !> Arguments: iwmix_virt, norbopt, norbvirt
-    use vmc_mod, only: MORB
+    use vmc_mod, only: norb_tot
 
-    integer, dimension(:, :), allocatable :: iwmix_virt !(MORB,MORB)
+    integer, dimension(:, :), allocatable :: iwmix_virt !(norb_tot,norb_tot)
     integer :: norbopt
     integer :: norbvirt
 
@@ -431,8 +431,8 @@ module optorb_mix
     save
 contains
     subroutine allocate_optorb_mix()
-        use vmc_mod, only: MORB
-        if (.not. allocated(iwmix_virt)) allocate (iwmix_virt(MORB, MORB))
+        use vmc_mod, only: norb_tot
+        if (.not. allocated(iwmix_virt)) allocate (iwmix_virt(norb_tot, norb_tot))
     end subroutine allocate_optorb_mix
 
     subroutine deallocate_optorb_mix()

--- a/src/vmc/m_vmc.f90
+++ b/src/vmc/m_vmc.f90
@@ -2,13 +2,13 @@ module vmc_mod
     !> Arguments:
     use precision_kinds, only: dp
 
-    ! nelec  >= number of electrons
-    ! MORB   >= number of orbitals
-    ! nbasis >= number of basis functions
-    ! ndet   >= number of determinants
-    ! ncent_tot  >= number of centers
-    ! nctype >= number of center types
-    ! nctyp3x = max(3,MCTYPE)
+    ! nelec      = number of electrons
+    ! norb_tot   = number of orbitals read from the orbital file
+    ! nbasis     = number of basis functions
+    ! ndet       = number of determinants
+    ! ncent_tot  = number of centers
+    ! nctype     = number of center types
+    ! nctyp3x    = max(3,MCTYPE)
 
     ! Slater matrices are dimensioned (MELEC/2)**2 assuming
     ! equal numbers of up and down spins. MELEC has to be
@@ -27,7 +27,7 @@ module vmc_mod
     integer, parameter :: nrad = 3001
     real(dp), parameter :: delri = (nrad - 1)/radmax
 
-    integer :: MORB
+    integer :: norb_tot
     integer :: nctyp3x
     integer, parameter :: NSPLIN = 1001, MORDJ = 7
 
@@ -41,7 +41,7 @@ module vmc_mod
     integer, parameter :: MEXCIT = 10
 
     private
-    public :: MORB, nctyp3x
+    public :: norb_tot, nctyp3x
     public :: NSPLIN, nrad, MORDJ, MORDJ1, nmat_dim, nmat_dim2
     public :: radmax, delri
 

--- a/src/vmc/multideterminant.f
+++ b/src/vmc/multideterminant.f
@@ -236,7 +236,7 @@ c compute Ymat for future use
 c-----------------------------------------------------------------------
       subroutine compute_ymat(iab,detu,detd,wfmat,ymat,istate)
 
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use vmc_mod, only: MEXCIT
       use const, only: nelec
       use dets, only: cdet, ndet
@@ -257,7 +257,7 @@ c-----------------------------------------------------------------------
       real(dp), dimension(ndet) :: detu
       real(dp), dimension(ndet) :: detd
       real(dp), dimension(MEXCIT**2, ndet) :: wfmat
-      real(dp), dimension(MORB, nelec) :: ymat
+      real(dp), dimension(norb_tot, nelec) :: ymat
       real(dp), parameter :: one = 1.d0
       real(dp), parameter :: half = 0.5d0
 
@@ -317,7 +317,7 @@ c-----------------------------------------------------------------------
 c-----------------------------------------------------------------------
       subroutine compute_dymat(iab,dymat)
 
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use vmc_mod, only: MEXCIT
       use const, only: nelec
       use dets, only: ndet
@@ -335,7 +335,7 @@ c-----------------------------------------------------------------------
       integer :: jj, jorb, jrep, kk
       integer :: ll, lorb, lrep, ndim
 
-      real(dp), dimension(MORB, nelec) :: dymat
+      real(dp), dimension(norb_tot, nelec) :: dymat
       real(dp), dimension(MEXCIT*MEXCIT) :: dmat1
       real(dp), dimension(MEXCIT*MEXCIT) :: dmat2
 
@@ -389,7 +389,7 @@ c-----------------------------------------------------------------------
 c-----------------------------------------------------------------------
       subroutine compute_zmat(ymat,dymat,zmat,dzmat,emz,aaz)
 
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use elec, only: ndn, nup
       use multidet, only: iactv, ivirt
       use coefs, only: norb
@@ -404,10 +404,10 @@ c-----------------------------------------------------------------------
       integer :: iab, irep, ish, jrep, krep
       integer :: nel
 
-      real(dp), dimension(MORB, nelec, 2) :: ymat
-      real(dp), dimension(MORB, nelec, 2) :: dymat
-      real(dp), dimension(MORB, nelec, 2) :: zmat
-      real(dp), dimension(MORB, nelec, 2) :: dzmat
+      real(dp), dimension(norb_tot, nelec, 2) :: ymat
+      real(dp), dimension(norb_tot, nelec, 2) :: dymat
+      real(dp), dimension(norb_tot, nelec, 2) :: zmat
+      real(dp), dimension(norb_tot, nelec, 2) :: dzmat
       real(dp), dimension(nelec, nelec, 2) :: emz
       real(dp), dimension(nelec, nelec, 2) :: aaz
 

--- a/src/vmc/multideterminante.f
+++ b/src/vmc/multideterminante.f
@@ -1,6 +1,6 @@
       subroutine multideterminante(iel)
 
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use vmc_mod, only: MEXCIT
       use csfs, only: nstates
       use dets, only: ndet
@@ -23,11 +23,11 @@
       integer :: jorb, jrep, k, ndim
       integer :: nel
       real(dp) :: det, dum1
-      real(dp), dimension(nelec, MORB, 3) :: gmat
+      real(dp), dimension(nelec, norb_tot, 3) :: gmat
       real(dp), dimension(MEXCIT**2, 3) :: gmatn
-      real(dp), dimension(MORB, 3) :: b
+      real(dp), dimension(norb_tot, 3) :: b
       real(dp), dimension(3) :: ddx_mdet
-      real(dp), dimension(MORB) :: orb_sav
+      real(dp), dimension(norb_tot) :: orb_sav
       real(dp), parameter :: one = 1.d0
       real(dp), parameter :: half = 0.5d0
 
@@ -124,7 +124,7 @@ c-----------------------------------------------------------------------
       subroutine multideterminante_grad(iel,dorb,detratio,slmi,aa,wfmat,ymat,velocity)
 
       use precision_kinds, only: dp
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use vmc_mod, only: nmat_dim
       use vmc_mod, only: MEXCIT
       use dets, only: ndet
@@ -140,12 +140,12 @@ c-----------------------------------------------------------------------
       integer :: j, jel, jrep, k
       integer :: kk, nel
       real(dp) :: detratio, dum
-      real(dp), dimension(nelec, MORB) :: aa
+      real(dp), dimension(nelec, norb_tot) :: aa
       real(dp), dimension(MEXCIT**2, ndet) :: wfmat
-      real(dp), dimension(MORB, nelec) :: ymat
-      real(dp), dimension(MORB, 3) :: b
-      real(dp), dimension(3, MORB) :: dorb
-      real(dp), dimension(nelec, MORB, 3) :: gmat
+      real(dp), dimension(norb_tot, nelec) :: ymat
+      real(dp), dimension(norb_tot, 3) :: b
+      real(dp), dimension(3, norb_tot) :: dorb
+      real(dp), dimension(nelec, norb_tot, 3) :: gmat
       real(dp), dimension(3) :: velocity
       real(dp), dimension(nmat_dim) :: slmi
       real(dp), parameter :: one = 1.d0

--- a/src/vmc/nonloc.f
+++ b/src/vmc/nonloc.f
@@ -2,7 +2,7 @@
 c Written by Claudia Filippi, modified by Cyrus Umrigar and A. Scemama
       use pseudo_mod, only: MPS_QUAD
       use optjas, only: MPARMJ
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use atom, only: iwctype, ncent, ncent_tot
       use const, only: nelec, ipr
       use elec, only: nup
@@ -54,9 +54,9 @@ c Written by Claudia Filippi, modified by Cyrus Umrigar and A. Scemama
       real(dp), dimension(*) :: dvpsp_dj
       real(dp), dimension(ncent_tot,MPS_QUAD,*) :: t_vpsp
       real(dp), dimension(MPARMJ) :: dpsij_ratio
-      real(dp), dimension(MORB) :: orbn
-      real(dp), dimension(3,MORB) :: dorbn
-      real(dp), dimension(3,ncent_tot,MORB) :: da_orbn
+      real(dp), dimension(norb_tot) :: orbn
+      real(dp), dimension(3,norb_tot) :: dorbn
+      real(dp), dimension(3,ncent_tot,norb_tot) :: da_orbn
       real(dp), dimension(3) :: term_radial_da_vps
       real(dp), dimension(3) :: vjn
       real(dp), dimension(3,ncent_tot) :: da_ratio_jn
@@ -638,7 +638,7 @@ c-----------------------------------------------------------------------
       subroutine compute_da_bnl(i,ic,ict,iq,r_en_sav,rvec_en_sav,costh,
      &                                   term_radial,orbn,dorbn,da_orbn,psij_ratio,vjn,da_ratio_jn)
 
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use atom, only: ncent, ncent_tot
       use Bloc, only: db
       use coefs, only: norb
@@ -657,10 +657,10 @@ c-----------------------------------------------------------------------
       real(dp) :: r_en_savi2, sav_db, term_radial, yl0
       real(dp), dimension(3,ncent_tot) :: rvec_en_sav
       real(dp), dimension(ncent_tot) :: r_en_sav
-      real(dp), dimension(MORB) :: orbn
-      real(dp), dimension(3,MORB) :: dorbn
+      real(dp), dimension(norb_tot) :: orbn
+      real(dp), dimension(3,norb_tot) :: dorbn
       real(dp), dimension(3) :: vjn
-      real(dp), dimension(3,ncent_tot,MORB) :: da_orbn
+      real(dp), dimension(3,ncent_tot,norb_tot) :: da_orbn
       real(dp), dimension(3,ncent_tot) :: da_ratio_jn
       real(dp), dimension(3) :: term_radial_da_vps
       real(dp), parameter :: one = 1.d0

--- a/src/vmc/optorb.f
+++ b/src/vmc/optorb.f
@@ -1,6 +1,6 @@
       subroutine optorb_deriv(psid,denergy,zmat,dzmat,emz,aaz,orbprim,eorbprim)
 
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use elec, only: ndn, nup
       use multidet, only: ivirt, kref
       use optwf_contrl, only: ioptorb
@@ -21,8 +21,8 @@
       integer :: iterm, jo, nel
       real(dp) :: denergy, detratio, dorb_energy, dorb_energy_ref, dorb_psi
       real(dp) :: dorb_psi_ref, psid
-      real(dp), dimension(MORB, nelec, 2) :: zmat
-      real(dp), dimension(MORB, nelec, 2) :: dzmat
+      real(dp), dimension(norb_tot, nelec, 2) :: zmat
+      real(dp), dimension(norb_tot, nelec, 2) :: dzmat
       real(dp), dimension(nelec, nelec, 2) :: emz
       real(dp), dimension(nelec, nelec, 2) :: aaz
       real(dp), dimension(*) :: orbprim
@@ -780,7 +780,7 @@ c-----------------------------------------------------------------------
       subroutine optorb_define
 
       use optorb_mod, only: MXORBOP, MXREDUCED
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use const, only: nelec
       use dets, only: ndet
       use elec, only: ndn, nup
@@ -806,7 +806,7 @@ c-----------------------------------------------------------------------
       integer :: n1, noporb
       integer, dimension(2, ndet) :: iodet
       integer, dimension(2, ndet) :: iopos
-      integer, dimension(2, MORB) :: iflag
+      integer, dimension(2, norb_tot) :: iflag
       integer, dimension(2) :: ne
       integer, dimension(2) :: m
 

--- a/src/vmc/optwf_handle_wf.f
+++ b/src/vmc/optwf_handle_wf.f
@@ -344,7 +344,7 @@ c-----------------------------------------------------------------------
       subroutine save_lcao
 
       use precision_kinds, only: dp
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use coefs, only: coef, nbasis, norb
       use wfsec, only: nwftype
 
@@ -353,7 +353,7 @@ c-----------------------------------------------------------------------
       integer :: i, iadiag, j
       real(dp), allocatable, save :: coef_save(:,:,:)
 
-      if (.not. allocated(coef_save)) allocate(coef_save(nbasis, MORB, nwftype))
+      if (.not. allocated(coef_save)) allocate(coef_save(nbasis, norb_tot, nwftype))
       ! dimension coef_save(nbasis,norb,MWF)
       ! save coef_save
 
@@ -364,7 +364,7 @@ c-----------------------------------------------------------------------
       return
 
       entry restore_lcao(iadiag)
-      if (.not. allocated(coef_save)) allocate(coef_save(nbasis, MORB, nwftype))
+      if (.not. allocated(coef_save)) allocate(coef_save(nbasis, norb_tot, nwftype))
 
       do 20 i=1,norb
        do 20 j=1,nbasis
@@ -593,7 +593,7 @@ c-----------------------------------------------------------------------
       subroutine save_lcao_best
 
       use precision_kinds, only: dp
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use coefs, only: coef, nbasis, norb
       use wfsec, only: nwftype
 
@@ -602,7 +602,7 @@ c-----------------------------------------------------------------------
       integer :: i, j
       real(dp), allocatable, save :: coef_best(:,:,:)
 
-      if (.not. allocated(coef_best)) allocate(coef_best(nbasis, MORB, nwftype))
+      if (.not. allocated(coef_best)) allocate(coef_best(nbasis, norb_tot, nwftype))
       ! dimension coef_best(nbasis,norb,MWF)
       ! save coef_best
 
@@ -615,7 +615,7 @@ c-----------------------------------------------------------------------
       entry restore_lcao_best
 
 c     if(ioptorb.eq.0) return
-      if (.not. allocated(coef_best)) allocate(coef_best(nbasis, MORB, nwftype))
+      if (.not. allocated(coef_best)) allocate(coef_best(nbasis, norb_tot, nwftype))
       do 20 i=1,norb
        do 20 j=1,nbasis
    20   coef(j,i,1)=coef_best(j,i,1)
@@ -748,7 +748,7 @@ c Check parameters a2 and b2 > -scalek
 c-----------------------------------------------------------------------
       subroutine compute_lcao(dparm,iadiag)
 
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use optwf_contrl, only: ioptorb
       use optwf_parms, only: nparmd, nparmj
       use coefs, only: coef, nbasis, norb
@@ -759,7 +759,7 @@ c-----------------------------------------------------------------------
       implicit none
 
       integer :: i, iadiag, io, j, jo
-      real(dp), dimension(nbasis, MORB) :: acoef
+      real(dp), dimension(nbasis, norb_tot) :: acoef
       real(dp), dimension(*) :: dparm
 
       if(ioptorb.eq.0) return

--- a/src/vmc/orbitals.f
+++ b/src/vmc/orbitals.f
@@ -176,9 +176,9 @@ c assuming that basis function values in phin are up to date
 
 c primary geometry only:
       iwf=1
-c      if(norb+nadorb.gt.MORB) then
+c      if(norb+nadorb.gt.norb_tot) then
 c        write(ounit,'(''VIRTUAL_ORB: Too many orbitals, norb + nadorb='',
-c     &  i4,'' > MORB='',i4)') norb+nadorb,MORB
+c     &  i4,'' > norb_tot='',i4)') norb+nadorb,norb_tot
 c        call fatal_error('Aborted')
 c      endif
 

--- a/src/vmc/parser.f90
+++ b/src/vmc/parser.f90
@@ -37,7 +37,7 @@ subroutine parser
   use pcm,              only: MCHS
   use mmpol_mod,      	only: mmpolfile_sites, mmpolfile_chmm
   use force_mod,      	only: MFORCE, MWF
-  use vmc_mod, 			    only: MORB
+  use vmc_mod, 			    only: norb_tot
   use atom, 			      only: znuc, cent, pecent, iwctype, nctype, ncent, ncent_tot, nctype_tot, symbol, atomtyp
   use jaspar, 			    only: nspin1, nspin2, is
   use ghostatom, 		    only: newghostype, nghostcent

--- a/src/vmc/pw_read.f
+++ b/src/vmc/pw_read.f
@@ -23,7 +23,7 @@ c$$$     &,cutr,cutr_sim,cutg,cutg_sim,cutg_big,cutg_sim_big
 c$$$     &,igvec(3,NGVEC_BIGX),gvec(3,NGVEC_BIGX),gnorm(NGNORM_BIGX),igmult(NGNORM_BIGX)
 c$$$     &,igvec_sim(3,NGVEC_SIM_BIGX),gvec_sim(3,NGVEC_SIM_BIGX),gnorm_sim(NGNORM_SIM_BIGX),igmult_sim(NGNORM_SIM_BIGX)
 c$$$     &,rkvec_shift(3),kvec(3,IVOL_RATIO),rkvec(3,IVOL_RATIO),rknorm(IVOL_RATIO)
-c$$$     &,k_inv(IVOL_RATIO),nband(IVOL_RATIO),ireal_imag(MORB)
+c$$$     &,k_inv(IVOL_RATIO),nband(IVOL_RATIO),ireal_imag(norb_tot)
 c$$$     &,znuc_sum,znuc2_sum,vcell,vcell_sim
 c$$$     &,ngnorm,ngvec,ngnorm_sim,ngvec_sim,ngnorm_orb,ngvec_orb,nkvec
 c$$$     &,ngnorm_big,ngvec_big,ngnorm_sim_big,ngvec_sim_big
@@ -175,7 +175,7 @@ c However, that causes problems when running with mpi, so comment out that part.
       use ewald_mod, only: IVOL_RATIO
       use ewald_mod, only: NGVECX
       use ewald_mod, only: NGVEC_BIGX
-      use vmc_mod, only: MORB
+      use vmc_mod, only: norb_tot
       use const, only: nelec
       use periodic, only: glatt
       use periodic, only: igmult, igvec
@@ -199,9 +199,9 @@ c However, that causes problems when running with mpi, so comment out that part.
       real(dp) :: eig, sum
       real(dp) :: sum_abs, units
       real(dp), dimension(3) :: r
-      real(dp), dimension(nelec,MORB) :: orb
-      real(dp), dimension(3,nelec,MORB) :: dorb
-      real(dp), dimension(nelec,MORB) :: ddorb
+      real(dp), dimension(nelec,norb_tot) :: orb
+      real(dp), dimension(3,nelec,norb_tot) :: dorb
+      real(dp), dimension(nelec,norb_tot) :: ddorb
 
 
 
@@ -215,8 +215,8 @@ c     dimension igvec_dft(3,NGVEC_BIGX),iwgvec(NGVEC_BIGX),c_real(NGVEC_BIGX),c_
 c    &,rkvec_tmp(3),rkvec_tmp2(3)
 
 c Warning: Temporary
-c Warning: why do I print out zeros if I dimension to MORB rather than IVOL_RATIO?
-c It should be MORB
+c Warning: why do I print out zeros if I dimension to norb_tot rather than IVOL_RATIO?
+c It should be norb_tot
 
 
 c Warning: For the moment we assume that orbitals_pw_tm contains only the bands we want to keep.

--- a/src/vmc/set_input_data.f90
+++ b/src/vmc/set_input_data.f90
@@ -51,7 +51,6 @@ end subroutine inputcsf
 subroutine multideterminants_define(iflag, icheck)
 
     use force_mod, only: MFORCE, MFORCE_WT_PRD, MWF
-    use vmc_mod, only: MORB
     use vmc_mod, only: NSPLIN, nrad, MORDJ, MORDJ1, nmat_dim, nmat_dim2
     use vmc_mod, only: radmax, delri
     use vmc_mod, only: NEQSX, MTERMS
@@ -313,7 +312,6 @@ subroutine inputdet()
     ! Set the cdet to be equal
     use dets, only: cdet, ndet
     use csfs, only: nstates
-!    use vmc_mod, only: MORB
 !    use mstates_mod, only: MSTATES
     use wfsec, only: nwftype
     use method_opt, only: method
@@ -337,7 +335,7 @@ end subroutine inputdet
 
 subroutine inputlcao()
     ! Set the lcao to be equal
-    use vmc_mod, only: MORB
+    use vmc_mod, only: norb_tot
     use coefs, only: coef, nbasis, norb
     use wfsec, only: nwftype
     use method_opt, only: method
@@ -347,9 +345,9 @@ subroutine inputlcao()
 
 
     if( (method(1:3) == 'lin')) then
-        if (.not. allocated(coef)) allocate (coef(nbasis, MORB, 3))
+        if (.not. allocated(coef)) allocate (coef(nbasis, norb_tot, 3))
     else
-        if (.not. allocated(coef)) allocate (coef(nbasis, MORB, nwftype))
+        if (.not. allocated(coef)) allocate (coef(nbasis, norb_tot, nwftype))
     endif
 
     do iwft = 2, nwftype


### PR DESCRIPTION
Step 1 of n:
 MORB being replaced. A new variable norb_tot is used for initial allocations after the orbitals files are read. The variable norb later corresponds to the final orbitals under optimization. 