### PR TITLE
[Mergeable] Add libopenmpi-dev to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Here are a couple of recipes for commonly used computing facilities, which can b
 		```
 	- Ubuntu 18:
 	Install the dependencies using conda instead of apt
-	- WSL
+	- WSL:
 	The code also compiles on WSL.
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
It might be installed by default on ubuntu, but this cost me some time. It is not installed by default on Debian, so Debian users should have a nicer time if this is included.