### PR TITLE
Improve CHAMP with OpenMP support for MKL (dgemv only)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,8 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
   else()
     set(BLA_VENDOR Intel10_64_dyn)
   endif()
+  add_definitions(-DUSE_MKL="True")
+  link_libraries(-liomp5)
 # write elseif part here for non-intel compilers
 endif()
 
@@ -154,7 +156,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
   #set(CMAKE_Fortran_FORMAT_FREE_FLAG "-ffree-form")
 
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
-  list(APPEND Fortran_FLAGS "-O2")
+  list(APPEND Fortran_FLAGS "-O2" "-g")
   list(APPEND Fortran_FLAGS "-implicitnone")
   list(APPEND Fortran_FLAGS "-finline" "-ip" "-align" "array64byte" "-fma" "-ftz" "-fomit-frame-pointer")
 	list(APPEND Fortran_FLAGS "-fpp" "-mcmodel=small" "-shared-intel" "-dyncom=grid3d_data,orbital_num_spl,orbital_num_lag,orbital_num_spl2,grid3d_data" )

--- a/src/module/m_mpi.f90
+++ b/src/module/m_mpi.f90
@@ -2,12 +2,13 @@ module mpiconf
     !> Arguments: idtask, nproc, wid
     integer  :: idtask
     integer  :: nproc
+    integer  :: nomp
     integer  :: ierr
     logical  :: wid
 
     private
     public :: idtask, nproc, wid
-    public :: mpiconf_init
+    public :: mpiconf_init, nomp
     save
 contains
     subroutine mpiconf_init()

--- a/src/vmc/main.f90
+++ b/src/vmc/main.f90
@@ -14,7 +14,10 @@
 program main
 
     use mpi
-    use mpiconf, only: idtask, nproc
+#ifdef USE_MKL
+      use omp_lib
+#endif 
+    use mpiconf, only: idtask, nproc, nomp
     use mpiconf, only: mpiconf_init
     use contr3, only: init_control_mode
     use contrl_file, only: init_logfile, init_procfile, close_files, initialize
@@ -35,6 +38,11 @@ program main
     call mpi_comm_rank(MPI_COMM_WORLD, idtask, ierr)
     call mpi_comm_size(MPI_COMM_WORLD, nproc, ierr)
 
+    !> If using MKL set it to serial execution by default
+#ifdef USE_MKL
+    nomp = omp_get_max_threads()
+    call mkl_set_num_threads(1)
+#endif
 
     time_start = time()
     !> init our own mpi vars

--- a/src/vmc/new_parser_read_data.f90
+++ b/src/vmc/new_parser_read_data.f90
@@ -7,7 +7,7 @@ subroutine header_printing()
     !! @author Ravindra Shinde (r.l.shinde@utwente.nl)
 
     use mpi
-    use mpiconf, only: idtask, nproc
+    use mpiconf, only: idtask, nproc, nomp
     use, intrinsic :: iso_fortran_env, only: iostat_end
     use contrl_file,    only: file_input, file_output, file_error
     use contrl_file,    only: ounit, errunit
@@ -105,6 +105,7 @@ subroutine header_printing()
     write(ounit, '(2a)') " Error file                 :: ",   file_error
     write(ounit, '(4a)') " Code compiled on           :: ",__DATE__, " at ", __TIME__
     write(ounit, '(a,i0)') " Number of processors       :: ", nproc
+    write(ounit, '(a,i0)') " Threads per  processor     :: ", nomp
 #if defined(TREXIO_FOUND)
     if (TREXIO_SUCCESS == 0) write(ounit,*) "TREXIO library version     :: ", TREXIO_PACKAGE_VERSION
 #endif

--- a/src/vmc/optwf_sr_more.f
+++ b/src/vmc/optwf_sr_more.f
@@ -1,4 +1,8 @@
       module sr_more
+#ifdef USE_MKL
+      use omp_lib
+#endif 
+      implicit none
       interface !LAPACK interface
 !*  -- Reference BLAS is a software package provided by Univ. of Tennessee,    --
 !*  -- Univ. of California Berkeley, Univ. of Colorado Denver and NAG Ltd..--
@@ -127,7 +131,7 @@ c r=a*z, i cicli doppi su n e nconf_n sono parallelizzati
       use sr_mat_n, only: jefj, jfj, jhfj, nconf_n, s_diag, sr_ho
       use sr_mat_n, only: sr_o, wtg, obs_tot
       use optorb_cblock, only: norbterm
-      use mpiconf, only: idtask
+      use mpiconf, only: idtask, nomp
       use mpi
       use precision_kinds, only: dp
 
@@ -176,6 +180,9 @@ c r=a*z, i cicli doppi su n e nconf_n sono parallelizzati
 !          rloc(i)=ddot(nconf_n,aux(1),1,sr_o(i,1),mparm)
 !        enddo
 
+#ifdef USE_MKL
+        call mkl_set_num_threads(nomp) !original number of threads
+#endif
         call dgemv('N', nparm_jasci, nconf_n, 1.0d0, sr_o(1,1), mparm, aux(1), 1, 0.0d0, rloc(1), 1)
 
 
@@ -188,6 +195,9 @@ c r=a*z, i cicli doppi su n e nconf_n sono parallelizzati
         i0 = nparm_jasci + 1 +(istate-1)*norbterm
         i1 = nparm_jasci + 1
         call dgemv('N', n - nparm_jasci, nconf_n, 1.0d0, sr_o(i0,1), mparm, aux(1), 1, 0.0d0, rloc(i1), 1)
+#ifdef USE_MKL
+        call mkl_set_num_threads(1)
+#endif
 
         call MPI_REDUCE(rloc,r_s,n,MPI_REAL8,MPI_SUM,0,MPI_COMM_WORLD,i)
 


### PR DESCRIPTION
- OpenMP support for MKL

- Selectively enables openmp for dgemv calls, ddot calls are still serial
- Speedup of 10% with OMP_NUM_THREADS=2 (optimal for this case) for VMC-Butadiene-ci1010_pVTZ-15000-dets

- More tests should be performed