### PR TITLE
WIP: Fix nup/ndn checks and nmat_dim for open-shell runs

### DIFF
--- a/src/module/m_common.f90
+++ b/src/module/m_common.f90
@@ -171,19 +171,6 @@ contains
 
 end module distances_sav
 
-module elec
-    !> Arguments: ndn, nup
-
-    implicit none
-
-    integer :: ndn
-    integer :: nup
-
-    private
-    public   :: ndn, nup
-    save
-end module elec
-
 module embed
     !> Never called
 

--- a/src/module/m_vmc.f90
+++ b/src/module/m_vmc.f90
@@ -1,3 +1,16 @@
+module elec
+    !> Arguments: ndn, nup
+
+    implicit none
+
+    integer :: ndn
+    integer :: nup
+
+    private
+    public   :: ndn, nup
+    save
+end module elec
+
 module vmc_mod
     !> Arguments:
     use precision_kinds, only: dp
@@ -56,7 +69,8 @@ contains
     subroutine set_vmc_size
         use const, only: nelec
         use atom, only: nctype_tot, ncent_tot
-        nmat_dim = nelec*nelec/4
+        use elec, only: nup  ! nup >= ndn
+        nmat_dim = nup*nup
         nmat_dim2 = nelec*(nelec - 1)/2
         nctyp3x = max(3, nctype_tot)
         ncent3 = 3*ncent_tot

--- a/src/vmc/parser.f90
+++ b/src/vmc/parser.f90
@@ -612,7 +612,7 @@ subroutine parser
   write(ounit,*)
 
   !checks
-  if(nup.gt.nelec/2) call fatal_error('INPUT: nup exceeds nelec/2')
+  if(nup.lt.nelec/2) call fatal_error('INPUT: nelec/2 exceeds nup')
 
   write(ounit,*)
   write(ounit,int_format) " Number of total electrons = ", nelec

--- a/src/vmc/set_input_data.f90
+++ b/src/vmc/set_input_data.f90
@@ -86,7 +86,7 @@ subroutine multideterminants_define(iflag, icheck)
     integer, dimension(nelec) :: auxdet
 
 
-    if (nup .gt. nelec/2) call fatal_error('INPUT: nup exceeds nelec/2')
+    if (nup .lt. nelec/2) call fatal_error('INPUT: nelec/2 exceeds nup')
     ndn = nelec - nup
 
     !!call p2gtid('general:nwftype', nwftype, 1, 1)


### PR DESCRIPTION
A few edits to fix data allocation in runs where nup > ndn, which would otherwise be (incorrectly) stopped and visit false parts of memory.

An open question for comments: is it okay to move ´module elec´ from src/m_common.f90 to src/m_vmc.f90, or should they be organized otherwise? I made the move to suppress a compiler warning for circular dependency loop, but the program works fine either way. I agree that ´module elec´ is more naturally located in src/m_common.f90, but some changes are necessary to deliver nup/ndn info inside src/m_vmc.f90. Feel free to suggest.

Another matter: although simple, this is potentially a breaking change, which has not yet been thoroughly tested. I recommend more testing before merging. Volunteer to do it myself later, if needed.