### PR TITLE
cmake requirement downgraded from 3.20 to 3.17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## Ravindra Shinde (2021) (c) TREX-CoE
 
-cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
 
 # Project's name
 project(CHAMP VERSION 2.0.5 LANGUAGES Fortran CXX C)


### PR DESCRIPTION
The hard requirement of cmake changed to 3.17 to accommodate older installations. No other changes are required in the CMakeLists file.