### PR TITLE
revert work size in matinv

### DIFF
--- a/src/vmc/matinv.f
+++ b/src/vmc/matinv.f
@@ -30,7 +30,7 @@
       real(dp) :: aux, determinant, deti
       real(dp) :: ten
       real(dp), dimension(nsub, nsub) :: a
-      real(dp), dimension(nsub) :: work
+      real(dp), dimension(nelec) :: work
 
       real(dp), dimension(2) :: det
       real(dp), parameter :: eps = 10.d0**(-40)


### PR DESCRIPTION
Fixed the bug I've introduced while changing array size from MELEC to nelec in matinv.
the size of the work array is now declared to be nelec instead of nsub