### PR TITLE
Fix conflicts jastrow subroutines and modules names

### DIFF
--- a/src/vmc/hpsi.f
+++ b/src/vmc/hpsi.f
@@ -20,7 +20,8 @@ c modified by Claudio Amovilli and Franca Floris for PCM and QM-MMPOl
       use force_analytic, only: compute_force
       use inputflags, only: iqmmm
       use jastrow, only: ianalyt_lap
-      use jastrow_mod, only: jastrow_f => jastrow
+c     use jastrow_mod, only: jastrow_f => jastrow
+      use jastrow_mod, only: jastrow_factor
       use jastrow_num_mod, only: jastrow_num
       use m_force_analytic, only: iforce_analy
       use mmpol,   only: mmpol_extpot_ene
@@ -121,7 +122,7 @@ c get contribution from jastrow (also compute derivatives wrt parameters and nuc
       if(nforce.gt.1) iwf=iwftype(ifr)
      
       if(ianalyt_lap.eq.1) then
-        call jastrow_f(coord,vj,d2j,psij,ifr)
+        call jastrow_factor(coord,vj,d2j,psij,ifr)
       else
         if(nforce.gt.1) then
           call jastrow_num(coord,vj(:,:,1),d2j(1),psij(1))

--- a/src/vmc/jastrow.f
+++ b/src/vmc/jastrow.f
@@ -1,6 +1,6 @@
       module jastrow_mod
       contains
-      subroutine jastrow(x,v,d2j,psij,ifr)
+      subroutine jastrow_factor(x,v,d2j,psij,ifr)
 c Written by Cyrus Umrigar
 
       use system, only: nelec
@@ -13,7 +13,7 @@ c Written by Cyrus Umrigar
       use vmc_mod, only: nwftypejas
       use derivjas, only: d2g, g, go, gvalue
       use contrl_file, only: ounit
-
+      use jastrow, only: ijas
       implicit none
 
       integer :: i, j, ifr


### PR DESCRIPTION
Hi @filippi-claudia and @v1kko , 

I create this pull request in my work merging with the periodic systems branch.  I found a problem when including variables from the **Jastrow module** in the **jastrow subroutine** which was really weird without apparent problems. 

@neelravi suggested the problem maybe naming then digging the problem was found. 
It was naming and a pointer created to the **jastrow subroutine** in src/vmc/hpsi.f. I change it seems to be working. I will wait to the test to run to merge it.   

best, 

Edgar