### PR TITLE
fixing orbitals vectorization

### DIFF
--- a/src/vmc/orbitals.f
+++ b/src/vmc/orbitals.f
@@ -65,7 +65,15 @@ c Modified by A. Scemama
 c     real(dp), dimension(nelec,nbasis) :: bhin
 c     real(dp), dimension(3*nelec,nbasis) :: dbhin
 c     real(dp), dimension(nelec,nbasis) :: d2bhin
+      real(dp), dimension(:), allocatable :: auxorb !(norb+nadorb)
+      real(dp), dimension(:, :), allocatable :: auxdorb !(norb+nadorb)
+      real(dp), dimension(:), allocatable :: auxddorb !(norb+nadorb)
+      if (.not. allocated(auxorb)) allocate (auxorb(norb+nadorb))
+      if (.not. allocated(auxdorb)) allocate (auxdorb(norb+nadorb,3))
+      if (.not. allocated(auxddorb)) allocate (auxddorb(norb+nadorb))
 
+
+      
 
 #ifdef QMCKL_FOUND
       real(dp), allocatable :: mo_vgl_qmckl(:,:,:)            
@@ -237,6 +245,9 @@ c     call dgemm('n','n',  nelec,norb,nbasis,1.d0,d2bhin, nelec,  coef(1,1,iwf),
             
             do k=1,nwftypeorb
                do i=1,nelec
+                  auxorb=0.d0
+                  auxdorb=0.d0
+                  auxddorb=0.d0
                   do iorb=1,norb+nadorb
                      orb(i,iorb,k)=0.d0
                      dorb(iorb,i,1,k)=0.d0
@@ -244,19 +255,30 @@ c     call dgemm('n','n',  nelec,norb,nbasis,1.d0,d2bhin, nelec,  coef(1,1,iwf),
                      dorb(iorb,i,3,k)=0.d0
                      ddorb(iorb,i,k)=0.d0
                      do m=1,nbasis
-                        orb  (  i,iorb,k)=orb  (  i,iorb,k)+coef(m,iorb,k)*phin  ( m,i)
-                        dorb (iorb,i,1,k)=dorb (iorb,i,1,k)+coef(m,iorb,k)*dphin (m,i,1)
-                        dorb (iorb,i,2,k)=dorb (iorb,i,2,k)+coef(m,iorb,k)*dphin (m,i,2)
-                        dorb (iorb,i,3,k)=dorb (iorb,i,3,k)+coef(m,iorb,k)*dphin (m,i,3)
-                        ddorb(  iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,k)*d2phin( m,i)
+c                        orb  (  i,iorb,k)=orb  (  i,iorb,k)+coef(m,iorb,k)*phin  ( m,i)
+c                        dorb (iorb,i,1,k)=dorb (iorb,i,1,k)+coef(m,iorb,k)*dphin (m,i,1)
+c                        dorb (iorb,i,2,k)=dorb (iorb,i,2,k)+coef(m,iorb,k)*dphin (m,i,2)
+c                        dorb (iorb,i,3,k)=dorb (iorb,i,3,k)+coef(m,iorb,k)*dphin (m,i,3)
+c                        ddorb(  iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,k)*d2phin( m,i)
+                        auxorb  (iorb)=auxorb  (iorb)+coef(m,iorb,k)*phin  ( m,i)
+                        auxdorb (iorb,1)=auxdorb (iorb,1)+coef(m,iorb,k)*dphin (m,i,1)
+                        auxdorb (iorb,2)=auxdorb (iorb,2)+coef(m,iorb,k)*dphin (m,i,2)
+                        auxdorb (iorb,3)=auxdorb (iorb,3)+coef(m,iorb,k)*dphin (m,i,3)
+                        auxddorb(  iorb)=auxddorb(iorb)+coef(m,iorb,k)*d2phin( m,i)
                      enddo
                   enddo
+                  orb(i,1:(norb+nadorb),k)=auxorb(1:(norb+nadorb))
+                  dorb(1:(norb+nadorb),i,1:3,k)=auxdorb(1:(norb+nadorb),1:3)
+                  ddorb(1:(norb+nadorb),i,k)=auxddorb(1:(norb+nadorb))
                enddo
             enddo
                         
          else
             
             do i=1,nelec
+                  auxorb=0.d0
+                  auxdorb=0.d0
+                  auxddorb=0.d0
                do iorb=1,norb+nadorb
                   orb(i,iorb,1)=0.d0
                   dorb(iorb,i,1,1)=0.d0
@@ -264,13 +286,21 @@ c     call dgemm('n','n',  nelec,norb,nbasis,1.d0,d2bhin, nelec,  coef(1,1,iwf),
                   dorb(iorb,i,3,1)=0.d0
                   ddorb(iorb,i,1)=0.d0
                   do m=1,nbasis
-                     orb  (  i,iorb,1)=orb  (  i,iorb,1)+coef(m,iorb,iwf)*phin  ( m,i)
-                     dorb (iorb,i,1,1)=dorb (iorb,i,1,1)+coef(m,iorb,iwf)*dphin (m,i,1)
-                     dorb (iorb,i,2,1)=dorb (iorb,i,2,1)+coef(m,iorb,iwf)*dphin (m,i,2)
-                     dorb (iorb,i,3,1)=dorb (iorb,i,3,1)+coef(m,iorb,iwf)*dphin (m,i,3)
-                     ddorb(  iorb,i,1)=ddorb(iorb,i,1)+coef(m,iorb,iwf)*d2phin( m,i)
+c                     orb  (  i,iorb,1)=orb  (  i,iorb,1)+coef(m,iorb,iwf)*phin  ( m,i)
+c                     dorb (iorb,i,1,1)=dorb (iorb,i,1,1)+coef(m,iorb,iwf)*dphin (m,i,1)
+c                     dorb (iorb,i,2,1)=dorb (iorb,i,2,1)+coef(m,iorb,iwf)*dphin (m,i,2)
+c                     dorb (iorb,i,3,1)=dorb (iorb,i,3,1)+coef(m,iorb,iwf)*dphin (m,i,3)
+c                     ddorb(  iorb,i,1)=ddorb(iorb,i,1)+coef(m,iorb,iwf)*d2phin( m,i)
+                     auxorb  (iorb)=auxorb  (iorb)+coef(m,iorb,iwf)*phin  ( m,i)
+                     auxdorb (iorb,1)=auxdorb (iorb,1)+coef(m,iorb,iwf)*dphin (m,i,1)
+                     auxdorb (iorb,2)=auxdorb (iorb,2)+coef(m,iorb,iwf)*dphin (m,i,2)
+                     auxdorb (iorb,3)=auxdorb (iorb,3)+coef(m,iorb,iwf)*dphin (m,i,3)
+                     auxddorb(  iorb)=auxddorb(iorb)+coef(m,iorb,iwf)*d2phin( m,i)
                   enddo
                enddo
+               orb(i,1:(norb+nadorb),1)=auxorb(1:(norb+nadorb))
+               dorb(1:(norb+nadorb),i,1:3,1)=auxdorb(1:(norb+nadorb),1:3)
+               ddorb(1:(norb+nadorb),i,1)=auxddorb(1:(norb+nadorb))
             enddo
             
             
@@ -287,6 +317,9 @@ c     call dgemm('n','n',  nelec,norb,nbasis,1.d0,d2bhin, nelec,  coef(1,1,iwf),
 
             do k=1,nwftypeorb
                do i=1,nelec
+                  auxorb=0.d0
+                  auxdorb=0.d0
+                  auxddorb=0.d0
                   do iorb=1,norb+nadorb
                      orb(i,iorb,k)=0.d0
                      dorb(iorb,i,1,k)=0.d0
@@ -295,19 +328,30 @@ c     call dgemm('n','n',  nelec,norb,nbasis,1.d0,d2bhin, nelec,  coef(1,1,iwf),
                      ddorb(iorb,i,k)=0.d0
                      do m0=1,n0_nbasis(i)
                         m=n0_ibasis(m0,i)
-                        orb  (  i,iorb,k)=orb  (  i,iorb,k)+coef(m,iorb,k)*phin  ( m,i)
-                        dorb (iorb,i,1,k)=dorb (iorb,i,1,k)+coef(m,iorb,k)*dphin (m,i,1)
-                        dorb (iorb,i,2,k)=dorb (iorb,i,2,k)+coef(m,iorb,k)*dphin (m,i,2)
-                        dorb (iorb,i,3,k)=dorb (iorb,i,3,k)+coef(m,iorb,k)*dphin (m,i,3)
-                        ddorb(iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,k)*d2phin( m,i)
+c     orb  (  i,iorb,k)=orb  (  i,iorb,k)+coef(m,iorb,k)*phin  ( m,i)
+c     dorb (iorb,i,1,k)=dorb (iorb,i,1,k)+coef(m,iorb,k)*dphin (m,i,1)
+c     dorb (iorb,i,2,k)=dorb (iorb,i,2,k)+coef(m,iorb,k)*dphin (m,i,2)
+c     dorb (iorb,i,3,k)=dorb (iorb,i,3,k)+coef(m,iorb,k)*dphin (m,i,3)
+c     ddorb(iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,k)*d2phin( m,i)
+                        auxorb  (iorb)=auxorb  (iorb)+coef(m,iorb,k)*phin  ( m,i)
+                        auxdorb (iorb,1)=auxdorb (iorb,1)+coef(m,iorb,k)*dphin (m,i,1)
+                        auxdorb (iorb,2)=auxdorb (iorb,2)+coef(m,iorb,k)*dphin (m,i,2)
+                        auxdorb (iorb,3)=auxdorb (iorb,3)+coef(m,iorb,k)*dphin (m,i,3)
+                        auxddorb(  iorb)=auxddorb(iorb)+coef(m,iorb,k)*d2phin( m,i)                        
                      enddo
                   enddo
+                  orb(i,1:(norb+nadorb),k)=auxorb(1:(norb+nadorb))
+                  dorb(1:(norb+nadorb),i,1:3,k)=auxdorb(1:(norb+nadorb),1:3)
+                  ddorb(1:(norb+nadorb),i,k)=auxddorb(1:(norb+nadorb))
                enddo
             enddo
                         
          else
             
             do i=1,nelec
+               auxorb=0.d0
+               auxdorb=0.d0
+               auxddorb=0.d0
                do iorb=1,norb+nadorb
                   orb(i,iorb,1)=0.d0
                   dorb(iorb,i,1,1)=0.d0
@@ -316,13 +360,21 @@ c     call dgemm('n','n',  nelec,norb,nbasis,1.d0,d2bhin, nelec,  coef(1,1,iwf),
                   ddorb(iorb,i,1)=0.d0
                   do m0=1,n0_nbasis(i)
                      m=n0_ibasis(m0,i)
-                     orb  (  i,iorb,1)=orb  (  i,iorb,1)+coef(m,iorb,iwf)*phin  ( m,i)
-                     dorb (iorb,i,1,1)=dorb (iorb,i,1,1)+coef(m,iorb,iwf)*dphin (m,i,1)
-                     dorb (iorb,i,2,1)=dorb (iorb,i,2,1)+coef(m,iorb,iwf)*dphin (m,i,2)
-                     dorb (iorb,i,3,1)=dorb (iorb,i,3,1)+coef(m,iorb,iwf)*dphin (m,i,3)
-                     ddorb(iorb,i,1)=ddorb(iorb,i,1)+coef(m,iorb,iwf)*d2phin( m,i)
+c                     orb  (  i,iorb,1)=orb  (  i,iorb,1)+coef(m,iorb,iwf)*phin  ( m,i)
+c                     dorb (iorb,i,1,1)=dorb (iorb,i,1,1)+coef(m,iorb,iwf)*dphin (m,i,1)
+c                     dorb (iorb,i,2,1)=dorb (iorb,i,2,1)+coef(m,iorb,iwf)*dphin (m,i,2)
+c                     dorb (iorb,i,3,1)=dorb (iorb,i,3,1)+coef(m,iorb,iwf)*dphin (m,i,3)
+c                     ddorb(iorb,i,1)=ddorb(iorb,i,1)+coef(m,iorb,iwf)*d2phin( m,i)
+                     auxorb  (iorb)=auxorb  (iorb)+coef(m,iorb,iwf)*phin  ( m,i)
+                     auxdorb (iorb,1)=auxdorb (iorb,1)+coef(m,iorb,iwf)*dphin (m,i,1)
+                     auxdorb (iorb,2)=auxdorb (iorb,2)+coef(m,iorb,iwf)*dphin (m,i,2)
+                     auxdorb (iorb,3)=auxdorb (iorb,3)+coef(m,iorb,iwf)*dphin (m,i,3)
+                     auxddorb(  iorb)=auxddorb(iorb)+coef(m,iorb,iwf)*d2phin( m,i)
                   enddo
                enddo
+               orb(i,1:(norb+nadorb),1)=auxorb(1:(norb+nadorb))
+               dorb(1:(norb+nadorb),i,1:3,1)=auxdorb(1:(norb+nadorb),1:3)
+               ddorb(1:(norb+nadorb),i,1)=auxddorb(1:(norb+nadorb))
             enddo
             
          endif

--- a/src/vmc/orbitals.f
+++ b/src/vmc/orbitals.f
@@ -1,4 +1,4 @@
-      module orbitals_mod
+iwf      module orbitals_mod
       interface !LAPACK interface
         SUBROUTINE dgemm(TRANSA,TRANSB,M,N,K,ALPHA,A,LDA,B,LDB,BETA,C,LDC)
 ! *  -- Reference BLAS level3 routine --
@@ -233,48 +233,102 @@ c     call dgemm('n','n',  nelec,norb,nbasis,1.d0,d2bhin, nelec,  coef(1,1,iwf),
 !     Vectorization dependent code selection
 #ifdef VECTORIZATION
 !     Following loop changed for better vectorization AVX512/AVX2
-
-          do k=1,nwftypeorb
-            if(nwftypeorb.gt.1) iwf=k
-            do i=1,nelec
-              do iorb=1,norb+nadorb
-                orb(i,iorb,k)=0.d0
-                dorb(iorb,i,1,k)=0.d0
-                dorb(iorb,i,2,k)=0.d0
-                dorb(iorb,i,3,k)=0.d0
-                ddorb(iorb,i,k)=0.d0
-                do m=1,nbasis
-                   orb  (  i,iorb,k)=orb  (  i,iorb,k)+coef(m,iorb,iwf)*phin  ( m,i)
-                   dorb (iorb,i,1,k)=dorb (iorb,i,1,k)+coef(m,iorb,iwf)*dphin (m,i,1)
-                   dorb (iorb,i,2,k)=dorb (iorb,i,2,k)+coef(m,iorb,iwf)*dphin (m,i,2)
-                   dorb (iorb,i,3,k)=dorb (iorb,i,3,k)+coef(m,iorb,iwf)*dphin (m,i,3)
-                   ddorb(  iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,iwf)*d2phin( m,i)
-                enddo
-              enddo
+         if(nwftypeorb.gt.1) then
+            
+            do k=1,nwftypeorb
+               do i=1,nelec
+                  do iorb=1,norb+nadorb
+                     orb(i,iorb,k)=0.d0
+                     dorb(iorb,i,1,k)=0.d0
+                     dorb(iorb,i,2,k)=0.d0
+                     dorb(iorb,i,3,k)=0.d0
+                     ddorb(iorb,i,k)=0.d0
+                     do m=1,nbasis
+                        orb  (  i,iorb,k)=orb  (  i,iorb,k)+coef(m,iorb,k)*phin  ( m,i)
+                        dorb (iorb,i,1,k)=dorb (iorb,i,1,k)+coef(m,iorb,k)*dphin (m,i,1)
+                        dorb (iorb,i,2,k)=dorb (iorb,i,2,k)+coef(m,iorb,k)*dphin (m,i,2)
+                        dorb (iorb,i,3,k)=dorb (iorb,i,3,k)+coef(m,iorb,k)*dphin (m,i,3)
+                        ddorb(  iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,k)*d2phin( m,i)
+                     enddo
+                  enddo
+               enddo
             enddo
-          enddo
+                        
+         else
+            
+            do i=1,nelec
+               do iorb=1,norb+nadorb
+                  orb(i,iorb,1)=0.d0
+                  dorb(iorb,i,1,1)=0.d0
+                  dorb(iorb,i,2,1)=0.d0
+                  dorb(iorb,i,3,1)=0.d0
+                  ddorb(iorb,i,1)=0.d0
+                  do m=1,nbasis
+                     orb  (  i,iorb,1)=orb  (  i,iorb,1)+coef(m,iorb,iwf)*phin  ( m,i)
+                     dorb (iorb,i,1,1)=dorb (iorb,i,1,1)+coef(m,iorb,iwf)*dphin (m,i,1)
+                     dorb (iorb,i,2,1)=dorb (iorb,i,2,1)+coef(m,iorb,iwf)*dphin (m,i,2)
+                     dorb (iorb,i,3,1)=dorb (iorb,i,3,1)+coef(m,iorb,iwf)*dphin (m,i,3)
+                     ddorb(  iorb,i,1)=ddorb(iorb,i,1)+coef(m,iorb,iwf)*d2phin( m,i)
+                  enddo
+               enddo
+            enddo
+            
+            
+         endif
+            
+         
+         
+
+         
 #else
 !     keep the old localization code if no vectorization instructions available
-          do k=1,nwftypeorb
-            if(nwftypeorb.gt.1) iwf=k
-            do i=1,nelec
-              do iorb=1,norb+nadorb
-                orb(i,iorb,k)=0.d0
-                dorb(iorb,i,1,k)=0.d0
-                dorb(iorb,i,2,k)=0.d0
-                dorb(iorb,i,3,k)=0.d0
-                ddorb(iorb,i,k)=0.d0
-                do m0=1,n0_nbasis(i)
-                   m=n0_ibasis(m0,i)
-                   orb  (  i,iorb,k)=orb  (  i,iorb,k)+coef(m,iorb,iwf)*phin  ( m,i)
-                   dorb (iorb,i,1,k)=dorb (iorb,i,1,k)+coef(m,iorb,iwf)*dphin (m,i,1)
-                   dorb (iorb,i,2,k)=dorb (iorb,i,2,k)+coef(m,iorb,iwf)*dphin (m,i,2)
-                   dorb (iorb,i,3,k)=dorb (iorb,i,3,k)+coef(m,iorb,iwf)*dphin (m,i,3)
-                   ddorb(iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,iwf)*d2phin( m,i)
-                enddo
-              enddo
+
+         if(nwftypeorb.gt.1) then
+
+            do k=1,nwftypeorb
+               do i=1,nelec
+                  do iorb=1,norb+nadorb
+                     orb(i,iorb,k)=0.d0
+                     dorb(iorb,i,1,k)=0.d0
+                     dorb(iorb,i,2,k)=0.d0
+                     dorb(iorb,i,3,k)=0.d0
+                     ddorb(iorb,i,k)=0.d0
+                     do m0=1,n0_nbasis(i)
+                        m=n0_ibasis(m0,i)
+                        orb  (  i,iorb,k)=orb  (  i,iorb,k)+coef(m,iorb,k)*phin  ( m,i)
+                        dorb (iorb,i,1,k)=dorb (iorb,i,1,k)+coef(m,iorb,k)*dphin (m,i,1)
+                        dorb (iorb,i,2,k)=dorb (iorb,i,2,k)+coef(m,iorb,k)*dphin (m,i,2)
+                        dorb (iorb,i,3,k)=dorb (iorb,i,3,k)+coef(m,iorb,k)*dphin (m,i,3)
+                        ddorb(iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,k)*d2phin( m,i)
+                     enddo
+                  enddo
+               enddo
             enddo
-          enddo
+                        
+         else
+            
+            do i=1,nelec
+               do iorb=1,norb+nadorb
+                  orb(i,iorb,1)=0.d0
+                  dorb(iorb,i,1,1)=0.d0
+                  dorb(iorb,i,2,1)=0.d0
+                  dorb(iorb,i,3,1)=0.d0
+                  ddorb(iorb,i,1)=0.d0
+                  do m0=1,n0_nbasis(i)
+                     m=n0_ibasis(m0,i)
+                     orb  (  i,iorb,1)=orb  (  i,iorb,1)+coef(m,iorb,iwf)*phin  ( m,i)
+                     dorb (iorb,i,1,1)=dorb (iorb,i,1,1)+coef(m,iorb,iwf)*dphin (m,i,1)
+                     dorb (iorb,i,2,1)=dorb (iorb,i,2,1)+coef(m,iorb,iwf)*dphin (m,i,2)
+                     dorb (iorb,i,3,1)=dorb (iorb,i,3,1)+coef(m,iorb,iwf)*dphin (m,i,3)
+                     ddorb(iorb,i,1)=ddorb(iorb,i,1)+coef(m,iorb,iwf)*d2phin( m,i)
+                  enddo
+               enddo
+            enddo
+            
+         endif
+
+         
+          
 #endif
 
 
@@ -517,7 +571,6 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
 
 #else
             
-            if(nwftypeorb.gt.1) iwf=1
 
             call basis_fns(iel,iel,nelec,rvec_en,r_en,ider)
 
@@ -525,44 +578,85 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
 #ifdef VECTORIZATION
 
             if(iflag.gt.0) then
-               do k=1,nwftypeorb
-                 if(nwftypeorb.gt.1) iwf=k
-                 do iorb=1,norb
-                    orbn(iorb,k)=0.d0
-                    dorbn(iorb,1,k)=0.d0
-                    dorbn(iorb,2,k)=0.d0
-                    dorbn(iorb,3,k)=0.d0
-                    ddorbn(iorb,k)=0.d0
-                    do m=1,nbasis
-                       orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,iwf)*phin(m,iel)
-                       dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,iwf)*dphin(m,iel,1)
-                       dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,iwf)*dphin(m,iel,2)
-                       dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
-                       ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,iwf)*d2phin(m,iel)
-                    enddo
-                 enddo
-               enddo
-               
+
+
+               if(nwftypeorb.gt.1) then
+                  
+                  do k=1,nwftypeorb
+                     do iorb=1,norb
+                        orbn(iorb,k)=0.d0
+                        dorbn(iorb,1,k)=0.d0
+                        dorbn(iorb,2,k)=0.d0
+                        dorbn(iorb,3,k)=0.d0
+                        ddorbn(iorb,k)=0.d0
+                        do m=1,nbasis
+                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
+                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
+                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
+                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
+                           ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,k)*d2phin(m,iel)
+                        enddo
+                     enddo
+                  enddo
+                  
+               else
+                  
+                  do iorb=1,norb
+                     orbn(iorb,1)=0.d0
+                     dorbn(iorb,1,1)=0.d0
+                     dorbn(iorb,2,1)=0.d0
+                     dorbn(iorb,3,1)=0.d0
+                     ddorbn(iorb,1)=0.d0
+                     do m=1,nbasis
+                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
+                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
+                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
+                        ddorbn(iorb,1)=ddorbn(iorb,1)+coef(m,iorb,iwf)*d2phin(m,iel)
+                     enddo
+                  enddo
+                  
+                  
+               endif
+
                
             else
 
-               do k=1,nwftypeorb
-                 if(nwftypeorb.gt.1) iwf=k
-                 do iorb=1,norb
-                    orbn(iorb,k)=0.d0
-                    dorbn(iorb,1,k)=0.d0
-                    dorbn(iorb,2,k)=0.d0
-                    dorbn(iorb,3,k)=0.d0
-                    do m=1,nbasis
-                       orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,iwf)*phin(m,iel)
-                       dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,iwf)*dphin(m,iel,1)
-                       dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,iwf)*dphin(m,iel,2)
-                       dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
-                    enddo
-                 enddo
-               enddo
-
-
+               if(nwftypeorb.gt.1) then
+                  
+                  do k=1,nwftypeorb
+                     do iorb=1,norb
+                        orbn(iorb,k)=0.d0
+                        dorbn(iorb,1,k)=0.d0
+                        dorbn(iorb,2,k)=0.d0
+                        dorbn(iorb,3,k)=0.d0
+                        do m=1,nbasis
+                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
+                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
+                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
+                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
+                        enddo
+                     enddo
+                  enddo
+                  
+               else
+                  
+                  do iorb=1,norb
+                     orbn(iorb,1)=0.d0
+                     dorbn(iorb,1,1)=0.d0
+                     dorbn(iorb,2,1)=0.d0
+                     dorbn(iorb,3,1)=0.d0
+                     do m=1,nbasis
+                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
+                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
+                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
+                     enddo
+                  enddo
+                  
+               endif
+               
+               
             endif
 
 
@@ -571,45 +665,94 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
 
 
             if(iflag.gt.0) then
-               do k=1,nwftypeorb
-                 if(nwftypeorb.gt.1) iwf=k
-                 do iorb=1,norb
-                    orbn(iorb,k)=0.d0
-                    dorbn(iorb,1,k)=0.d0
-                    dorbn(iorb,2,k)=0.d0
-                    dorbn(iorb,3,k)=0.d0
-                    ddorbn(iorb,k)=0.d0
-                    do m0=1,n0_nbasis(iel)
-                       m=n0_ibasis(m0,iel)
-                       orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,iwf)*phin(m,iel)
-                       dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,iwf)*dphin(m,iel,1)
-                       dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,iwf)*dphin(m,iel,2)
-                       dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
-                       ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,iwf)*d2phin(m,iel)
-                    enddo
-                 enddo
-               enddo
+
+               
+               if(nwftypeorb.gt.1) then
+
+                  do k=1,nwftypeorb
+                     do iorb=1,norb
+                        orbn(iorb,k)=0.d0
+                        dorbn(iorb,1,k)=0.d0
+                        dorbn(iorb,2,k)=0.d0
+                        dorbn(iorb,3,k)=0.d0
+                        ddorbn(iorb,k)=0.d0
+                        do m0=1,n0_nbasis(iel)
+                           m=n0_ibasis(m0,iel)
+                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
+                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
+                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
+                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
+                           ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,k)*d2phin(m,iel)
+                        enddo
+                     enddo
+                  enddo
+                  
+               else
+
+                  do iorb=1,norb
+                        orbn(iorb,1)=0.d0
+                        dorbn(iorb,1,1)=0.d0
+                        dorbn(iorb,2,1)=0.d0
+                        dorbn(iorb,3,1)=0.d0
+                        ddorbn(iorb,1)=0.d0
+                        do m0=1,n0_nbasis(iel)
+                           m=n0_ibasis(m0,iel)
+                           orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
+                           dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+                           dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
+                           dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
+                           ddorbn(iorb,1)=ddorbn(iorb,1)+coef(m,iorb,iwf)*d2phin(m,iel)
+                        enddo
+                     enddo
+                  enddo
+
+               endif
+
+               
+              
 
 
             else
 
-               do k=1,nwftypeorb
-                 if(nwftypeorb.gt.1) iwf=k
-                 do iorb=1,norb
-                    orbn(iorb,k)=0.d0
-                    dorbn(iorb,1,k)=0.d0
-                    dorbn(iorb,2,k)=0.d0
-                    dorbn(iorb,3,k)=0.d0
-                    do m0=1,n0_nbasis(iel)
-                       m=n0_ibasis(m0,iel)
-                       orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,iwf)*phin(m,iel)
-                       dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,iwf)*dphin(m,iel,1)
-                       dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,iwf)*dphin(m,iel,2)
-                       dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
-                    enddo
-                 enddo
-               enddo
 
+               if(nwftypeorb.gt.1) then
+
+
+                  do k=1,nwftypeorb
+                     do iorb=1,norb
+                        orbn(iorb,k)=0.d0
+                        dorbn(iorb,1,k)=0.d0
+                        dorbn(iorb,2,k)=0.d0
+                        dorbn(iorb,3,k)=0.d0
+                        do m0=1,n0_nbasis(iel)
+                           m=n0_ibasis(m0,iel)
+                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
+                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
+                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
+                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
+                        enddo
+                     enddo
+                  enddo
+                  
+               else
+
+                  do iorb=1,norb
+                     orbn(iorb,1)=0.d0
+                     dorbn(iorb,1,1)=0.d0
+                     dorbn(iorb,2,1)=0.d0
+                     dorbn(iorb,3,1)=0.d0
+                     do m0=1,n0_nbasis(iel)
+                        m=n0_ibasis(m0,iel)
+                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
+                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
+                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
+                     enddo
+                  enddo
+                                    
+               endif
+
+               
                
             endif
 

--- a/src/vmc/orbitals.f
+++ b/src/vmc/orbitals.f
@@ -509,13 +509,7 @@ c-------------------------------------------------------------------------------
       real(dp), dimension(3,*) :: x
       real(dp), dimension(3,nelec,ncent_tot) :: rvec_en
       real(dp), dimension(nelec,ncent_tot) :: r_en
-      real(dp), dimension(:), allocatable :: auxorbn !(norb)
-      real(dp), dimension(:, :), allocatable :: auxdorbn !(norb)
-      real(dp), dimension(:), allocatable :: auxddorbn !(norb)
-      if (.not. allocated(auxorbn)) allocate (auxorbn(norb))
-      if (.not. allocated(auxdorbn)) allocate (auxdorbn(norb,3))
-      if (.not. allocated(auxddorbn)) allocate (auxddorbn(norb))
-      
+
 
 #ifdef QMCKL_FOUND
 c     real(dp), allocatable :: mo_vgl_qmckl(:,:,:)
@@ -641,9 +635,6 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
                if(nwftypeorb.gt.1) then
                   
                   do k=1,nwftypeorb
-                     auxorbn=0.d0
-                     auxdorbn=0.d0
-                     auxddorbn=0.d0
                      do iorb=1,norb
                         orbn(iorb,k)=0.d0
                         dorbn(iorb,1,k)=0.d0
@@ -651,28 +642,17 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
                         dorbn(iorb,3,k)=0.d0
                         ddorbn(iorb,k)=0.d0
                         do m=1,nbasis
-c                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
-c                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
-c                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
-c                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
-c                           ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,k)*d2phin(m,iel)
-                           auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,k)*phin(m,iel)
-                           auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,k)*dphin(m,iel,1)
-                           auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,k)*dphin(m,iel,2)
-                           auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,k)*dphin(m,iel,3)
-                           auxddorbn(iorb)=auxddorbn(iorb)+coef(m,iorb,k)*d2phin(m,iel)
+                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
+                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
+                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
+                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
+                           ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,k)*d2phin(m,iel)
                         enddo
                      enddo
-                     orbn(1:norb,k)=auxorbn
-                     dorbn(1:norb,1:3,k)=auxdorbn
-                     ddorbn(1:norb,k)=auxddorbn
                   enddo
                   
                else
-
-                  auxorbn=0.d0
-                  auxdorbn=0.d0
-                  auxddorbn=0.d0
+                  
                   do iorb=1,norb
                      orbn(iorb,1)=0.d0
                      dorbn(iorb,1,1)=0.d0
@@ -680,21 +660,14 @@ c                           ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,k)*d2phin(
                      dorbn(iorb,3,1)=0.d0
                      ddorbn(iorb,1)=0.d0
                      do m=1,nbasis
-c                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
-c                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
-c                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
-c                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
-c                        ddorbn(iorb,1)=ddorbn(iorb,1)+coef(m,iorb,iwf)*d2phin(m,iel)
-                        auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,iwf)*phin(m,iel)
-                        auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
-                        auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,iwf)*dphin(m,iel,2)
-                        auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,iwf)*dphin(m,iel,3)
-                        auxddorbn(iorb)=auxddorbn(iorb)+coef(m,iorb,iwf)*d2phin(m,iel)
+                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
+                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
+                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
+                        ddorbn(iorb,1)=ddorbn(iorb,1)+coef(m,iorb,iwf)*d2phin(m,iel)
                      enddo
                   enddo
-                  orbn(1:norb,1)=auxorbn
-                  dorbn(1:norb,1:3,1)=auxdorbn
-                  ddorbn(1:norb,1)=auxddorbn
+                  
                   
                endif
 
@@ -704,50 +677,34 @@ c                        ddorbn(iorb,1)=ddorbn(iorb,1)+coef(m,iorb,iwf)*d2phin(m
                if(nwftypeorb.gt.1) then
                   
                   do k=1,nwftypeorb
-                     auxorbn=0.d0
-                     auxdorbn=0.d0
                      do iorb=1,norb
                         orbn(iorb,k)=0.d0
                         dorbn(iorb,1,k)=0.d0
                         dorbn(iorb,2,k)=0.d0
                         dorbn(iorb,3,k)=0.d0
                         do m=1,nbasis
-c                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
-c                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
-c                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
-c                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
-                           auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,k)*phin(m,iel)
-                           auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,k)*dphin(m,iel,1)
-                           auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,k)*dphin(m,iel,2)
-                           auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,k)*dphin(m,iel,3)
+                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
+                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
+                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
+                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
                         enddo
                      enddo
-                     orbn(1:norb,k)=auxorbn
-                     dorbn(1:norb,1:3,k)=auxdorbn
                   enddo
                   
                else
-
-                  auxorbn=0.d0
-                  auxdorbn=0.d0
+                  
                   do iorb=1,norb
                      orbn(iorb,1)=0.d0
                      dorbn(iorb,1,1)=0.d0
                      dorbn(iorb,2,1)=0.d0
                      dorbn(iorb,3,1)=0.d0
                      do m=1,nbasis
-c                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
-c                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
-c                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
-c                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
-                        auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,iwf)*phin(m,iel)
-                        auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
-                        auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,iwf)*dphin(m,iel,2)
-                        auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,iwf)*dphin(m,iel,3)
+                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
+                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
+                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
                      enddo
                   enddo
-                  orbn(1:norb,1)=auxorbn
-                  dorbn(1:norb,1:3,1)=auxdorbn
                   
                endif
                
@@ -765,9 +722,6 @@ c                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(
                if(nwftypeorb.gt.1) then
 
                   do k=1,nwftypeorb
-                     auxorbn=0.d0
-                     auxdorbn=0.d0
-                     auxddorbn=0.d0
                      do iorb=1,norb
                         orbn(iorb,k)=0.d0
                         dorbn(iorb,1,k)=0.d0
@@ -776,28 +730,17 @@ c                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(
                         ddorbn(iorb,k)=0.d0
                         do m0=1,n0_nbasis(iel)
                            m=n0_ibasis(m0,iel)
-c                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
-c                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
-c                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
-c                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
-c                           ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,k)*d2phin(m,iel)
-                           auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,k)*phin(m,iel)
-                           auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,k)*dphin(m,iel,1)
-                           auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,k)*dphin(m,iel,2)
-                           auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,k)*dphin(m,iel,3)
-                           auxddorbn(iorb)=auxddorbn(iorb)+coef(m,iorb,k)*d2phin(m,iel)
+                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
+                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
+                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
+                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
+                           ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,k)*d2phin(m,iel)
                         enddo
                      enddo
-                     orbn(1:norb,k)=auxorbn
-                     dorbn(1:norb,1:3,k)=auxdorbn
-                     ddorbn(1:norb,k)=auxddorbn
                   enddo
                   
                else
-
-                  auxorbn=0.d0
-                  auxdorbn=0.d0
-                  auxddorbn=0.d0
+                  
                   do iorb=1,norb
                      orbn(iorb,1)=0.d0
                      dorbn(iorb,1,1)=0.d0
@@ -806,25 +749,19 @@ c                           ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,k)*d2phin(
                      ddorbn(iorb,1)=0.d0
                      do m0=1,n0_nbasis(iel)
                         m=n0_ibasis(m0,iel)
-c                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
-c                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
-c                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
-c                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
-c                        ddorbn(iorb,1)=ddorbn(iorb,1)+coef(m,iorb,iwf)*d2phin(m,iel)
-                        auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,iwf)*phin(m,iel)
-                        auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
-                        auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,iwf)*dphin(m,iel,2)
-                        auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,iwf)*dphin(m,iel,3)
-                        auxddorbn(iorb)=auxddorbn(iorb)+coef(m,iorb,iwf)*d2phin(m,iel)
+                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
+                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
+                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
+                        ddorbn(iorb,1)=ddorbn(iorb,1)+coef(m,iorb,iwf)*d2phin(m,iel)
                      enddo
                   enddo
-                  orbn(1:norb,1)=auxorbn
-                  dorbn(1:norb,1:3,1)=auxdorbn
-                  ddorbn(1:norb,1)=auxddorbn
-                  
+               
                endif
 
                
+              
+
 
             else
 
@@ -833,8 +770,6 @@ c                        ddorbn(iorb,1)=ddorbn(iorb,1)+coef(m,iorb,iwf)*d2phin(m
 
 
                   do k=1,nwftypeorb
-                     auxorbn=0.d0
-                     auxdorbn=0.d0
                      do iorb=1,norb
                         orbn(iorb,k)=0.d0
                         dorbn(iorb,1,k)=0.d0
@@ -842,24 +777,16 @@ c                        ddorbn(iorb,1)=ddorbn(iorb,1)+coef(m,iorb,iwf)*d2phin(m
                         dorbn(iorb,3,k)=0.d0
                         do m0=1,n0_nbasis(iel)
                            m=n0_ibasis(m0,iel)
-c                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
-c                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
-c                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
-c                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
-                           auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,k)*phin(m,iel)
-                           auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,k)*dphin(m,iel,1)
-                           auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,k)*dphin(m,iel,2)
-                           auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,k)*dphin(m,iel,3)
+                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
+                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
+                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
+                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
                         enddo
                      enddo
-                     orbn(1:norb,k)=auxorbn
-                     dorbn(1:norb,1:3,k)=auxdorbn
                   enddo
                   
                else
 
-                  auxorbn=0.d0
-                  auxdorbn=0.d0
                   do iorb=1,norb
                      orbn(iorb,1)=0.d0
                      dorbn(iorb,1,1)=0.d0
@@ -867,19 +794,13 @@ c                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin
                      dorbn(iorb,3,1)=0.d0
                      do m0=1,n0_nbasis(iel)
                         m=n0_ibasis(m0,iel)
-c                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
-c                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
-c                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
-c                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
-                        auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,iwf)*phin(m,iel)
-                        auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
-                        auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,iwf)*dphin(m,iel,2)
-                        auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,iwf)*dphin(m,iel,3)
+                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
+                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
+                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
                      enddo
                   enddo
-                  orbn(1:norb,1)=auxorbn
-                  dorbn(1:norb,1:3,1)=auxdorbn
-                                       
+                                    
                endif
 
                

--- a/src/vmc/orbitals.f
+++ b/src/vmc/orbitals.f
@@ -1,4 +1,4 @@
-iwf      module orbitals_mod
+      module orbitals_mod
       interface !LAPACK interface
         SUBROUTINE dgemm(TRANSA,TRANSB,M,N,K,ALPHA,A,LDA,B,LDB,BETA,C,LDC)
 ! *  -- Reference BLAS level3 routine --

--- a/src/vmc/orbitals.f
+++ b/src/vmc/orbitals.f
@@ -740,24 +740,23 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
                   enddo
                   
                else
-
+                  
                   do iorb=1,norb
-                        orbn(iorb,1)=0.d0
-                        dorbn(iorb,1,1)=0.d0
-                        dorbn(iorb,2,1)=0.d0
-                        dorbn(iorb,3,1)=0.d0
-                        ddorbn(iorb,1)=0.d0
-                        do m0=1,n0_nbasis(iel)
-                           m=n0_ibasis(m0,iel)
-                           orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
-                           dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
-                           dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
-                           dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
-                           ddorbn(iorb,1)=ddorbn(iorb,1)+coef(m,iorb,iwf)*d2phin(m,iel)
-                        enddo
+                     orbn(iorb,1)=0.d0
+                     dorbn(iorb,1,1)=0.d0
+                     dorbn(iorb,2,1)=0.d0
+                     dorbn(iorb,3,1)=0.d0
+                     ddorbn(iorb,1)=0.d0
+                     do m0=1,n0_nbasis(iel)
+                        m=n0_ibasis(m0,iel)
+                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
+                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
+                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
+                        ddorbn(iorb,1)=ddorbn(iorb,1)+coef(m,iorb,iwf)*d2phin(m,iel)
                      enddo
                   enddo
-
+               
                endif
 
                

--- a/src/vmc/orbitals.f
+++ b/src/vmc/orbitals.f
@@ -211,7 +211,8 @@ c     get basis functions for all electrons
 #else
 
          call basis_fns(1,nelec,nelec,rvec_en,r_en,ider)
-
+c        this call is independ of vectorization  
+         if(nwftypeorb.gt.1) iwf=1
 
 
 c in alternativa al loop 26
@@ -235,45 +236,45 @@ c     call dgemm('n','n',  nelec,norb,nbasis,1.d0,d2bhin, nelec,  coef(1,1,iwf),
 !     Following loop changed for better vectorization AVX512/AVX2
 
           do k=1,nwftypeorb
-            if(nwftypeorb.gt.1) iwf=k
-            do i=1,nelec
-              do iorb=1,norb+nadorb
-                orb(i,iorb,k)=0.d0
-                dorb(iorb,i,1,k)=0.d0
-                dorb(iorb,i,2,k)=0.d0
-                dorb(iorb,i,3,k)=0.d0
-                ddorb(iorb,i,k)=0.d0
-                do m=1,nbasis
-                   orb  (  i,iorb,k)=orb  (  i,iorb,k)+coef(m,iorb,iwf)*phin  ( m,i)
-                   dorb (iorb,i,1,k)=dorb (iorb,i,1,k)+coef(m,iorb,iwf)*dphin (m,i,1)
-                   dorb (iorb,i,2,k)=dorb (iorb,i,2,k)+coef(m,iorb,iwf)*dphin (m,i,2)
-                   dorb (iorb,i,3,k)=dorb (iorb,i,3,k)+coef(m,iorb,iwf)*dphin (m,i,3)
-                   ddorb(  iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,iwf)*d2phin( m,i)
+             iwf=iwf+(k-1)
+             do i=1,nelec
+                do iorb=1,norb+nadorb
+                   orb(i,iorb,k)=0.d0
+                   dorb(iorb,i,1,k)=0.d0
+                   dorb(iorb,i,2,k)=0.d0
+                   dorb(iorb,i,3,k)=0.d0
+                   ddorb(iorb,i,k)=0.d0
+                   do m=1,nbasis
+                      orb  (  i,iorb,k)=orb  (  i,iorb,k)+coef(m,iorb,iwf)*phin  ( m,i)
+                      dorb (iorb,i,1,k)=dorb (iorb,i,1,k)+coef(m,iorb,iwf)*dphin (m,i,1)
+                      dorb (iorb,i,2,k)=dorb (iorb,i,2,k)+coef(m,iorb,iwf)*dphin (m,i,2)
+                      dorb (iorb,i,3,k)=dorb (iorb,i,3,k)+coef(m,iorb,iwf)*dphin (m,i,3)
+                      ddorb(  iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,iwf)*d2phin( m,i)
+                   enddo
                 enddo
-              enddo
-            enddo
+             enddo
           enddo
 #else
 !     keep the old localization code if no vectorization instructions available
           do k=1,nwftypeorb
-            if(nwftypeorb.gt.1) iwf=k
-            do i=1,nelec
-              do iorb=1,norb+nadorb
-                orb(i,iorb,k)=0.d0
-                dorb(iorb,i,1,k)=0.d0
-                dorb(iorb,i,2,k)=0.d0
-                dorb(iorb,i,3,k)=0.d0
-                ddorb(iorb,i,k)=0.d0
-                do m0=1,n0_nbasis(i)
-                   m=n0_ibasis(m0,i)
-                   orb  (  i,iorb,k)=orb  (  i,iorb,k)+coef(m,iorb,iwf)*phin  ( m,i)
-                   dorb (iorb,i,1,k)=dorb (iorb,i,1,k)+coef(m,iorb,iwf)*dphin (m,i,1)
-                   dorb (iorb,i,2,k)=dorb (iorb,i,2,k)+coef(m,iorb,iwf)*dphin (m,i,2)
-                   dorb (iorb,i,3,k)=dorb (iorb,i,3,k)+coef(m,iorb,iwf)*dphin (m,i,3)
-                   ddorb(iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,iwf)*d2phin( m,i)
+             iwf=iwf+(k-1)
+             do i=1,nelec
+                do iorb=1,norb+nadorb
+                   orb(i,iorb,k)=0.d0
+                   dorb(iorb,i,1,k)=0.d0
+                   dorb(iorb,i,2,k)=0.d0
+                   dorb(iorb,i,3,k)=0.d0
+                   ddorb(iorb,i,k)=0.d0
+                   do m0=1,n0_nbasis(i)
+                      m=n0_ibasis(m0,i)
+                      orb  (  i,iorb,k)=orb  (  i,iorb,k)+coef(m,iorb,iwf)*phin  ( m,i)
+                      dorb (iorb,i,1,k)=dorb (iorb,i,1,k)+coef(m,iorb,iwf)*dphin (m,i,1)
+                      dorb (iorb,i,2,k)=dorb (iorb,i,2,k)+coef(m,iorb,iwf)*dphin (m,i,2)
+                      dorb (iorb,i,3,k)=dorb (iorb,i,3,k)+coef(m,iorb,iwf)*dphin (m,i,3)
+                      ddorb(iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,iwf)*d2phin( m,i)
+                   enddo
                 enddo
-              enddo
-            enddo
+             enddo
           enddo
 #endif
 
@@ -523,33 +524,33 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
 
 !     Vectorization dependent code. useful for AVX512 and AVX2
 #ifdef VECTORIZATION
-
+            
             if(iflag.gt.0) then
                do k=1,nwftypeorb
-                 if(nwftypeorb.gt.1) iwf=k
-                 do iorb=1,norb
-                    orbn(iorb,k)=0.d0
-                    dorbn(iorb,1,k)=0.d0
-                    dorbn(iorb,2,k)=0.d0
-                    dorbn(iorb,3,k)=0.d0
-                    ddorbn(iorb,k)=0.d0
-                    do m=1,nbasis
-                       orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,iwf)*phin(m,iel)
-                       dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,iwf)*dphin(m,iel,1)
-                       dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,iwf)*dphin(m,iel,2)
-                       dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
-                       ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,iwf)*d2phin(m,iel)
-                    enddo
-                 enddo
+                  iwf=iwf+(k-1)
+                  do iorb=1,norb
+                     orbn(iorb,k)=0.d0
+                     dorbn(iorb,1,k)=0.d0
+                     dorbn(iorb,2,k)=0.d0
+                     dorbn(iorb,3,k)=0.d0
+                     ddorbn(iorb,k)=0.d0
+                     do m=1,nbasis
+                        orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,iwf)*phin(m,iel)
+                        dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,iwf)*dphin(m,iel,1)
+                        dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,iwf)*dphin(m,iel,2)
+                        dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
+                        ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,iwf)*d2phin(m,iel)
+                     enddo
+                  enddo
                enddo
                
                
             else
-
+               
                do k=1,nwftypeorb
-                 if(nwftypeorb.gt.1) iwf=k
-                 do iorb=1,norb
-                    orbn(iorb,k)=0.d0
+                  iwf=iwf+(k-1)
+                  do iorb=1,norb
+                     orbn(iorb,k)=0.d0
                     dorbn(iorb,1,k)=0.d0
                     dorbn(iorb,2,k)=0.d0
                     dorbn(iorb,3,k)=0.d0
@@ -561,10 +562,10 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
                     enddo
                  enddo
                enddo
-
+               
 
             endif
-
+            
 
 #else
 !     Keep the localization for the non-vectorized code
@@ -572,7 +573,7 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
 
             if(iflag.gt.0) then
                do k=1,nwftypeorb
-                 if(nwftypeorb.gt.1) iwf=k
+                 iwf=iwf+(k-1)
                  do iorb=1,norb
                     orbn(iorb,k)=0.d0
                     dorbn(iorb,1,k)=0.d0
@@ -594,7 +595,7 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
             else
 
                do k=1,nwftypeorb
-                 if(nwftypeorb.gt.1) iwf=k
+                  iwf=iwf+(k-1)
                  do iorb=1,norb
                     orbn(iorb,k)=0.d0
                     dorbn(iorb,1,k)=0.d0
@@ -608,24 +609,24 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
                        dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
                     enddo
                  enddo
-               enddo
+              enddo
 
-               
-            endif
-
-
-#endif
+              
+           endif
 
 
 #endif
-         endif
-c endif for ier
+           
+
+#endif
+        endif
+c     endif for ier
       else
          do k=1,nwftypeorb
            call orbitals_pw_grade(iel,x(1,iel),orbn(:,k),dorbn(:,:,k),ddorbn(:,k))
-         enddo
+        enddo
       endif
-
+      
       return
       end
 c------------------------------------------------------------------------------------

--- a/src/vmc/orbitals.f
+++ b/src/vmc/orbitals.f
@@ -268,9 +268,9 @@ c                      ddorb(  iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,iwf)*d2phin
                       auxddorb(iorb)=auxddorb(iorb)+coef(m,iorb,iwf)*d2phin( m,i)
                    enddo
                 enddo
-                orb(i,1:norb+nadorb,k)=auxorb
-                dorb(1:norb+nadorb,i,:,k)=auxdorb
-                ddorb(1:norb+nadorb,i,k)=auxddorb
+                orb(i,1:(norb+nadorb),k)=auxorb(1:(norb+nadorb))
+                dorb(1:(norb+nadorb),i,1:3,k)=auxdorb(1:(norb+nadorb),1:3)
+                ddorb(1:(norb+nadorb),i,k)=auxddorb(1:(norb+nadorb))
              enddo
           enddo
 #else
@@ -301,9 +301,9 @@ c     ddorb(iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,iwf)*d2phin( m,i)
                       auxddorb(iorb)=auxddorb(iorb)+coef(m,iorb,iwf)*d2phin( m,i)
                    enddo
                 enddo
-                orb(i,1:norb+nadorb,k)=auxorb
-                dorb(1:norb+nadorb,i,:,k)=auxdorb
-                ddorb(1:norb+nadorb,i,k)=auxddorb
+                orb(i,1:(norb+nadorb),k)=auxorb(1:(norb+nadorb))
+                dorb(1:(norb+nadorb),i,1:3,k)=auxdorb(1:(norb+nadorb),1:3)
+                ddorb(1:(norb+nadorb),i,k)=auxddorb(1:(norb+nadorb))
              enddo
           enddo
 #endif
@@ -588,9 +588,9 @@ c     ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,iwf)*d2phin(m,iel)
                         auxddorbn(iorb)=auxddorbn(iorb)+coef(m,iorb,iwf)*d2phin(m,iel)
                      enddo
                   enddo
-                    orbn(1:norb,k)=auxorbn
-                    dorbn(1:norb,:,k)=auxdorbn
-                    ddorbn(1:norb,k)=auxddorbn
+                    orbn(1:norb,k)=auxorbn(1:norb)
+                    dorbn(1:norb,1:3,k)=auxdorbn(1:norb,1:3)
+                    ddorbn(1:norb,k)=auxddorbn(1:norb)
                enddo
                
                
@@ -616,8 +616,8 @@ c     dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
                         auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,iwf)*dphin(m,iel,3)
                      enddo
                   enddo
-                  orbn(1:norb,k)=auxorbn
-                  dorbn(1:norb,:,k)=auxdorbn
+                  orbn(1:norb,k)=auxorbn(1:norb)
+                  dorbn(1:norb,1:3,k)=auxdorbn(1:norb,1:3)
                 enddo
                
 
@@ -654,9 +654,10 @@ c     ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,iwf)*d2phin(m,iel)
                         auxddorbn(iorb)=auxddorbn(iorb)+coef(m,iorb,iwf)*d2phin(m,iel)
                     enddo
                  enddo
-                 orbn(1:norb,k)=auxorbn
-                 dorbn(1:norb,:,k)=auxdorbn
-                 ddorbn(1:norb,k)=auxddorbn                 
+                 orbn(1:norb,k)=auxorbn(1:norb)
+                 dorbn(1:norb,1:3,k)=auxdorbn(1:norb,1:3)
+                 ddorbn(1:norb,k)=auxddorbn(1:norb)
+
                enddo
 
 
@@ -683,8 +684,8 @@ c     dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
                         auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,iwf)*dphin(m,iel,3)
                      enddo
                   enddo
-                  orbn(1:norb,k)=auxorbn
-                  dorbn(1:norb,:,k)=auxdorbn
+                  orbn(1:norb,k)=auxorbn(1:norb)
+                  dorbn(1:norb,1:3,k)=auxdorbn(1:norb,1:3)
                enddo
 
                

--- a/src/vmc/orbitals.f
+++ b/src/vmc/orbitals.f
@@ -65,7 +65,14 @@ c Modified by A. Scemama
 c     real(dp), dimension(nelec,nbasis) :: bhin
 c     real(dp), dimension(3*nelec,nbasis) :: dbhin
 c     real(dp), dimension(nelec,nbasis) :: d2bhin
-
+      real(dp), dimension(:), allocatable :: auxorb !(norb+nadorb)
+      real(dp), dimension(:, :), allocatable :: auxdorb !(norb+nadorb)
+      real(dp), dimension(:), allocatable :: auxddorb !(norb+nadorb)
+      if (.not. allocated(auxorb)) allocate (auxorb(norb+nadorb))
+      if (.not. allocated(auxdorb)) allocate (auxdorb(norb+nadorb,3))
+      if (.not. allocated(auxddorb)) allocate (auxddorb(norb+nadorb))
+      
+      
 
 #ifdef QMCKL_FOUND
       real(dp), allocatable :: mo_vgl_qmckl(:,:,:)            
@@ -78,75 +85,79 @@ c     real(dp), dimension(nelec,nbasis) :: d2bhin
       if(iperiodic.eq.0) then
 
 c spline interpolation
-        if(i3dsplorb.eq.2) then
-          do k=1,nwftypeorb
-            do i=1,nelec
-            ier = 0.d0
-              do iorb=1,norb+nadorb
-                ddorb(iorb,i,k)=1.d0    ! compute the laplacian
-                dorb(iorb,i,1,k)=1.d0   ! compute the gradients
-                dorb(iorb,i,2,k)=1.d0   ! compute the gradients
-                dorb(iorb,i,3,k)=1.d0   ! compute the gradients
-                call spline_mo(x(1,i),iorb,orb(i,iorb,k),dorb(iorb,i,:,k),ddorb(iorb,i,k),ier)
+         if(i3dsplorb.eq.2) then
+            if(nwftypeorb.gt.1) iwf=1
+            do k=1,nwftypeorb
+              iwf=iwf+(k-1)
+              do i=1,nelec
+                 ier = 0.d0
+                 do iorb=1,norb+nadorb
+                    ddorb(iorb,i,k)=1.d0 ! compute the laplacian
+                    dorb(iorb,i,1,k)=1.d0 ! compute the gradients
+                    dorb(iorb,i,2,k)=1.d0 ! compute the gradients
+                    dorb(iorb,i,3,k)=1.d0 ! compute the gradients
+                    call spline_mo(x(1,i),iorb,orb(i,iorb,k),dorb(iorb,i,:,k),ddorb(iorb,i,k),ier)
+                 enddo
+                 if(ier.eq.1) then
+
+                    call basis_fns(i,i,nelec,rvec_en,r_en,2)
+                
+                    do iorb=1,norb+nadorb
+                       orb(i,iorb,k)=0.d0
+                       dorb(iorb,i,1,k)=0.d0
+                       dorb(iorb,i,2,k)=0.d0
+                       dorb(iorb,i,3,k)=0.d0
+                       ddorb(iorb,i,k)=0.d0
+                       do m0=1,n0_nbasis(i)
+                          m=n0_ibasis(m0,i)
+                          orb(i,iorb,k)=orb(i,iorb,k)+coef(m,iorb,iwf)*phin(m,i)
+                          dorb(iorb,i,1,k)=dorb(iorb,i,1,k)+coef(m,iorb,iwf)*dphin(m,i,1)
+                          dorb(iorb,i,2,k)=dorb(iorb,i,2,k)+coef(m,iorb,iwf)*dphin(m,i,2)
+                          dorb(iorb,i,3,k)=dorb(iorb,i,3,k)+coef(m,iorb,iwf)*dphin(m,i,3)
+                          ddorb(iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,iwf)*d2phin(m,i)
+                       enddo
+                    enddo
+                 endif
               enddo
-              if(ier.eq.1) then
-
-                call basis_fns(i,i,nelec,rvec_en,r_en,2)
-
-                do iorb=1,norb+nadorb
-                  orb(i,iorb,k)=0.d0
-                  dorb(iorb,i,1,k)=0.d0
-                  dorb(iorb,i,2,k)=0.d0
-                  dorb(iorb,i,3,k)=0.d0
-                  ddorb(iorb,i,k)=0.d0
-                  do m0=1,n0_nbasis(i)
-                    m=n0_ibasis(m0,i)
-                    orb(i,iorb,k)=orb(i,iorb,k)+coef(m,iorb,iwf)*phin(m,i)
-                    dorb(iorb,i,1,k)=dorb(iorb,i,1,k)+coef(m,iorb,iwf)*dphin(m,i,1)
-                    dorb(iorb,i,2,k)=dorb(iorb,i,2,k)+coef(m,iorb,iwf)*dphin(m,i,2)
-                    dorb(iorb,i,3,k)=dorb(iorb,i,3,k)+coef(m,iorb,iwf)*dphin(m,i,3)
-                    ddorb(iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,iwf)*d2phin(m,i)
-                  enddo
-                enddo
-              endif
-            enddo
-          enddo
+           enddo
 !         
 ! Lagrange interpolation, did not inclue multiorb here yet
         elseif(i3dlagorb.eq.2) then
-         do k=1,nwftypeorb
-           do i=1,nelec
-             ier=0
-             call lagrange_mos(1,x(1,i),orb(1,1,k),i,ier)
-             call lagrange_mos_grad(2,x(1,i),dorb(1,1,1,k),i,ier)
-             call lagrange_mos_grad(3,x(1,i),dorb(1,1,1,k),i,ier)
-             call lagrange_mos_grad(4,x(1,i),dorb(1,1,1,k),i,ier)
-             call lagrange_mos_2(5,x(1,i),ddorb(1,1,k),i,ier)
+           if(nwftypeorb.gt.1) iwf=1
+           do k=1,nwftypeorb
+              iwf=iwf+(k-1)
+              do i=1,nelec
+                 ier=0
+                 call lagrange_mos(1,x(1,i),orb(1,1,k),i,ier)
+                 call lagrange_mos_grad(2,x(1,i),dorb(1,1,1,k),i,ier)
+                 call lagrange_mos_grad(3,x(1,i),dorb(1,1,1,k),i,ier)
+                 call lagrange_mos_grad(4,x(1,i),dorb(1,1,1,k),i,ier)
+                 call lagrange_mos_2(5,x(1,i),ddorb(1,1,k),i,ier)
 
-             if(ier.eq.1) then
+                 if(ier.eq.1) then
 
-              if(nwftypeorb.gt.1) iwf=1
-              call basis_fns(i,i,nelec,rvec_en,r_en,2)
-              if(nwftypeorb.gt.1) iwf=k
+c     if(nwftypeorb.gt.1) iwf=1
+                    call basis_fns(i,i,nelec,rvec_en,r_en,2)
+c     if(nwftypeorb.gt.1) iwf=k
 
-               do iorb=1,norb+nadorb
-                 orb(i,iorb,k)=0.d0
-                 dorb(iorb,i,1,k)=0.d0
-                 dorb(iorb,i,2,k)=0.d0
-                 dorb(iorb,i,3,k)=0.d0
-                 ddorb(iorb,i,k)=0.d0
-                 do m0=1,n0_nbasis(i)
-                   m=n0_ibasis(m0,i)
-                   orb(i,iorb,k)=orb(i,iorb,k)+coef(m,iorb,iwf)*phin(m,i)
-                   dorb(iorb,i,1,k)=dorb(iorb,i,1,k)+coef(m,iorb,iwf)*dphin(m,i,1)
-                   dorb(iorb,i,2,k)=dorb(iorb,i,2,k)+coef(m,iorb,iwf)*dphin(m,i,2)
-                   dorb(iorb,i,3,k)=dorb(iorb,i,3,k)+coef(m,iorb,iwf)*dphin(m,i,3)
-                   ddorb(iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,iwf)*d2phin(m,i)
-                 enddo
-               enddo
-             endif
+                    do iorb=1,norb+nadorb
+                       orb(i,iorb,k)=0.d0
+                       dorb(iorb,i,1,k)=0.d0
+                       dorb(iorb,i,2,k)=0.d0
+                       dorb(iorb,i,3,k)=0.d0
+                       ddorb(iorb,i,k)=0.d0
+                       do m0=1,n0_nbasis(i)
+                          m=n0_ibasis(m0,i)
+                          orb(i,iorb,k)=orb(i,iorb,k)+coef(m,iorb,iwf)*phin(m,i)
+                          dorb(iorb,i,1,k)=dorb(iorb,i,1,k)+coef(m,iorb,iwf)*dphin(m,i,1)
+                          dorb(iorb,i,2,k)=dorb(iorb,i,2,k)+coef(m,iorb,iwf)*dphin(m,i,2)
+                          dorb(iorb,i,3,k)=dorb(iorb,i,3,k)+coef(m,iorb,iwf)*dphin(m,i,3)
+                          ddorb(iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,iwf)*d2phin(m,i)
+                       enddo
+                    enddo
+                 endif
+              enddo
            enddo
-         enddo
 
 c no 3d interpolation
       else
@@ -229,50 +240,72 @@ c     enddo
 c     call dgemm('n','n',  nelec,norb,nbasis,1.d0,bhin,   nelec,  coef(1,1,iwf),nbasis,0.d0,orb,   nelec)
 c     call dgemm('n','n',3*nelec,norb,nbasis,1.d0,dbhin,3*nelec,  coef(1,1,iwf),nbasis,0.d0,dorb,3*nelec)
 c     call dgemm('n','n',  nelec,norb,nbasis,1.d0,d2bhin, nelec,  coef(1,1,iwf),nbasis,0.d0,ddorb, nelec)
+
+c     calls independent of vectorization or not
+         if(nwftypeorb.gt.1) iwf=1
+         orb=0.d0
+         dorb=0.d0
+         ddorb=0.d0
+
          
 !     Vectorization dependent code selection
 #ifdef VECTORIZATION
 !     Following loop changed for better vectorization AVX512/AVX2
-
+ 
           do k=1,nwftypeorb
-            if(nwftypeorb.gt.1) iwf=k
-            do i=1,nelec
+c     if(nwftypeorb.gt.1) iwf=k
+             iwf=iwf+(k-1)
+             do i=1,nelec
+                auxorb=0.d0
+                auxdorb=0.d0
+                auxddorb=0.d0
               do iorb=1,norb+nadorb
-                orb(i,iorb,k)=0.d0
-                dorb(iorb,i,1,k)=0.d0
-                dorb(iorb,i,2,k)=0.d0
-                dorb(iorb,i,3,k)=0.d0
-                ddorb(iorb,i,k)=0.d0
                 do m=1,nbasis
-                   orb  (  i,iorb,k)=orb  (  i,iorb,k)+coef(m,iorb,iwf)*phin  ( m,i)
-                   dorb (iorb,i,1,k)=dorb (iorb,i,1,k)+coef(m,iorb,iwf)*dphin (m,i,1)
-                   dorb (iorb,i,2,k)=dorb (iorb,i,2,k)+coef(m,iorb,iwf)*dphin (m,i,2)
-                   dorb (iorb,i,3,k)=dorb (iorb,i,3,k)+coef(m,iorb,iwf)*dphin (m,i,3)
-                   ddorb(  iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,iwf)*d2phin( m,i)
+c                   orb  (  i,iorb,k)=orb  (  i,iorb,k)+coef(m,iorb,iwf)*phin  ( m,i)
+c                   dorb (iorb,i,1,k)=dorb (iorb,i,1,k)+coef(m,iorb,iwf)*dphin (m,i,1)
+c                   dorb (iorb,i,2,k)=dorb (iorb,i,2,k)+coef(m,iorb,iwf)*dphin (m,i,2)
+c                   dorb (iorb,i,3,k)=dorb (iorb,i,3,k)+coef(m,iorb,iwf)*dphin (m,i,3)
+c                   ddorb(  iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,iwf)*d2phin( m,i)
+                   auxorb  (iorb)=auxorb(iorb)+coef(m,iorb,iwf)*phin  ( m,i)
+                   auxdorb (iorb,1)=auxdorb(iorb,1)+coef(m,iorb,iwf)*dphin (m,i,1)
+                   auxdorb (iorb,2)=auxdorb(iorb,2)+coef(m,iorb,iwf)*dphin (m,i,2)
+                   auxdorb (iorb,3)=auxdorb(iorb,3)+coef(m,iorb,iwf)*dphin (m,i,3)
+                   auxddorb(iorb)=auxddorb(iorb)+coef(m,iorb,iwf)*d2phin( m,i)                   
                 enddo
-              enddo
+             enddo
+             orb(i,:,k)=auxorb
+             dorb(:,i,:,k)=auxdorb
+             ddorb(:,i,k)=auxddorb
             enddo
           enddo
 #else
 !     keep the old localization code if no vectorization instructions available
+          
           do k=1,nwftypeorb
-            if(nwftypeorb.gt.1) iwf=k
-            do i=1,nelec
-              do iorb=1,norb+nadorb
-                orb(i,iorb,k)=0.d0
-                dorb(iorb,i,1,k)=0.d0
-                dorb(iorb,i,2,k)=0.d0
-                dorb(iorb,i,3,k)=0.d0
-                ddorb(iorb,i,k)=0.d0
+c     if(nwftypeorb.gt.1) iwf=k
+             iwf=iwf+(k-1)
+             do i=1,nelec
+                auxorb=0.d0
+                auxdorb=0.d0
+                auxddorb=0.d0
+                do iorb=1,norb+nadorb
                 do m0=1,n0_nbasis(i)
                    m=n0_ibasis(m0,i)
-                   orb  (  i,iorb,k)=orb  (  i,iorb,k)+coef(m,iorb,iwf)*phin  ( m,i)
-                   dorb (iorb,i,1,k)=dorb (iorb,i,1,k)+coef(m,iorb,iwf)*dphin (m,i,1)
-                   dorb (iorb,i,2,k)=dorb (iorb,i,2,k)+coef(m,iorb,iwf)*dphin (m,i,2)
-                   dorb (iorb,i,3,k)=dorb (iorb,i,3,k)+coef(m,iorb,iwf)*dphin (m,i,3)
-                   ddorb(iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,iwf)*d2phin( m,i)
+c     orb  (  i,iorb,k)=orb  (  i,iorb,k)+coef(m,iorb,iwf)*phin  ( m,i)
+c     dorb (iorb,i,1,k)=dorb (iorb,i,1,k)+coef(m,iorb,iwf)*dphin (m,i,1)
+c     dorb (iorb,i,2,k)=dorb (iorb,i,2,k)+coef(m,iorb,iwf)*dphin (m,i,2)
+c     dorb (iorb,i,3,k)=dorb (iorb,i,3,k)+coef(m,iorb,iwf)*dphin (m,i,3)
+c     ddorb(iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,iwf)*d2phin( m,i)
+                   auxorb  (iorb)=auxorb(iorb)+coef(m,iorb,iwf)*phin  ( m,i)
+                   auxdorb (iorb,1)=auxdorb(iorb,1)+coef(m,iorb,iwf)*dphin (m,i,1)
+                   auxdorb (iorb,2)=auxdorb(iorb,2)+coef(m,iorb,iwf)*dphin (m,i,2)
+                   auxdorb (iorb,3)=auxdorb(iorb,3)+coef(m,iorb,iwf)*dphin (m,i,3)
+                   auxddorb(iorb)=auxddorb(iorb)+coef(m,iorb,iwf)*d2phin( m,i)
                 enddo
-              enddo
+             enddo
+             orb(i,:,k)=auxorb
+             dorb(:,i,:,k)=auxdorb
+             ddorb(:,i,k)=auxddorb
             enddo
           enddo
 #endif
@@ -403,8 +436,16 @@ c-------------------------------------------------------------------------------
       real(dp), dimension(3,*) :: x
       real(dp), dimension(3,nelec,ncent_tot) :: rvec_en
       real(dp), dimension(nelec,ncent_tot) :: r_en
-
-
+c     auxiliary arrays temporal loops for vectorization      
+      real(dp), dimension(:), allocatable :: auxorbn !(norb)
+      real(dp), dimension(:, :), allocatable :: auxdorbn !(norb)
+      real(dp), dimension(:), allocatable :: auxddorbn !(norb)
+      if (.not. allocated(auxorbn)) allocate (auxorbn(norb))
+      if (.not. allocated(auxdorbn)) allocate (auxdorbn(norb,3))
+      if (.not. allocated(auxddorbn)) allocate (auxddorbn(norb))
+            
+      
+      
 #ifdef QMCKL_FOUND
 c     real(dp), allocatable :: mo_vgl_qmckl(:,:,:)
       real(dp), allocatable :: mo_vgl_qmckl(:,:)
@@ -517,49 +558,71 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
 
 #else
             
-            if(nwftypeorb.gt.1) iwf=1
-
+            
             call basis_fns(iel,iel,nelec,rvec_en,r_en,ider)
 
+c     this call is independt of vectorization
+            if(nwftypeorb.gt.1) iwf=1
+            orbn=0.d0
+            dorbn=0.d0
+            ddorbn=0.d0
+            
+            
 !     Vectorization dependent code. useful for AVX512 and AVX2
 #ifdef VECTORIZATION
 
+            
             if(iflag.gt.0) then
+
                do k=1,nwftypeorb
-                 if(nwftypeorb.gt.1) iwf=k
-                 do iorb=1,norb
-                    orbn(iorb,k)=0.d0
-                    dorbn(iorb,1,k)=0.d0
-                    dorbn(iorb,2,k)=0.d0
-                    dorbn(iorb,3,k)=0.d0
-                    ddorbn(iorb,k)=0.d0
+c     if(nwftypeorb.gt.1) iwf=k
+                  iwf=iwf+(k-1)
+                  auxorbn=0.d0
+                  auxdorbn=0.d0
+                  auxddorbn=0.d0
+                  do iorb=1,norb
                     do m=1,nbasis
-                       orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,iwf)*phin(m,iel)
-                       dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,iwf)*dphin(m,iel,1)
-                       dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,iwf)*dphin(m,iel,2)
-                       dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
-                       ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,iwf)*d2phin(m,iel)
+c     orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,iwf)*phin(m,iel)
+c     dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,iwf)*dphin(m,iel,1)
+c     dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,iwf)*dphin(m,iel,2)
+c     dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
+c     ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,iwf)*d2phin(m,iel)
+                       auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,iwf)*phin(m,iel)
+                       auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+                       auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,iwf)*dphin(m,iel,2)
+                       auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,iwf)*dphin(m,iel,3)
+                       auxddorbn(iorb)=auxddorbn(iorb)+coef(m,iorb,iwf)*d2phin(m,iel)
                     enddo
                  enddo
+                 orbn(1:norb,k)=auxorbn
+                 dorbn(1:norb,:,k)=auxdorbn
+                 ddorbn(1:norb,k)=auxddorbn
                enddo
                
                
             else
-
+               
+               
+               
                do k=1,nwftypeorb
-                 if(nwftypeorb.gt.1) iwf=k
+c     if(nwftypeorb.gt.1) iwf=k
+                  iwf=iwf+(k-1)
+                  auxorbn=0.d0
+                  auxdorbn=0.d0
                  do iorb=1,norb
-                    orbn(iorb,k)=0.d0
-                    dorbn(iorb,1,k)=0.d0
-                    dorbn(iorb,2,k)=0.d0
-                    dorbn(iorb,3,k)=0.d0
                     do m=1,nbasis
-                       orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,iwf)*phin(m,iel)
-                       dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,iwf)*dphin(m,iel,1)
-                       dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,iwf)*dphin(m,iel,2)
-                       dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
+c     orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,iwf)*phin(m,iel)
+c     dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,iwf)*dphin(m,iel,1)
+c     dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,iwf)*dphin(m,iel,2)
+c     dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
+                       auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,iwf)*phin(m,iel)
+                       auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+                       auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,iwf)*dphin(m,iel,2)
+                       auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,iwf)*dphin(m,iel,3)
                     enddo
                  enddo
+                 orbn(1:norb,k)=auxorbn
+                 dorbn(1:norb,:,k)=auxdorbn
                enddo
 
 
@@ -571,44 +634,57 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
 
 
             if(iflag.gt.0) then
+               
                do k=1,nwftypeorb
-                 if(nwftypeorb.gt.1) iwf=k
+c     if(nwftypeorb.gt.1) iwf=k
+                  iwf=iwf+(k-1)
+                  auxorbn=0.d0
+                  auxdorbn=0.d0
+                  auxddorbn=0.d0
                  do iorb=1,norb
-                    orbn(iorb,k)=0.d0
-                    dorbn(iorb,1,k)=0.d0
-                    dorbn(iorb,2,k)=0.d0
-                    dorbn(iorb,3,k)=0.d0
-                    ddorbn(iorb,k)=0.d0
                     do m0=1,n0_nbasis(iel)
                        m=n0_ibasis(m0,iel)
-                       orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,iwf)*phin(m,iel)
-                       dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,iwf)*dphin(m,iel,1)
-                       dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,iwf)*dphin(m,iel,2)
-                       dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
-                       ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,iwf)*d2phin(m,iel)
+c     orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,iwf)*phin(m,iel)
+c     dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,iwf)*dphin(m,iel,1)
+c     dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,iwf)*dphin(m,iel,2)
+c     dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
+c     ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,iwf)*d2phin(m,iel)
+                       auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,iwf)*phin(m,iel)
+                       auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+                       auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,iwf)*dphin(m,iel,2)
+                       auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,iwf)*dphin(m,iel,3)
+                       auxddorbn(iorb)=auxddorbn(iorb)+coef(m,iorb,iwf)*d2phin(m,iel)                       
                     enddo
                  enddo
+                 orbn(1:norb,k)=auxorbn
+                 dorbn(1:norb,:,k)=auxdorbn
+                 ddorbn(1:norb,k)=auxddorbn
                enddo
 
 
             else
 
                do k=1,nwftypeorb
-                 if(nwftypeorb.gt.1) iwf=k
+c     if(nwftypeorb.gt.1) iwf=k
+                  iwf=iwf+(k-1)
+                  auxorbn=0.d0
+                  auxdorbn=0.d0
                  do iorb=1,norb
-                    orbn(iorb,k)=0.d0
-                    dorbn(iorb,1,k)=0.d0
-                    dorbn(iorb,2,k)=0.d0
-                    dorbn(iorb,3,k)=0.d0
                     do m0=1,n0_nbasis(iel)
                        m=n0_ibasis(m0,iel)
-                       orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,iwf)*phin(m,iel)
-                       dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,iwf)*dphin(m,iel,1)
-                       dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,iwf)*dphin(m,iel,2)
-                       dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
+c     orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,iwf)*phin(m,iel)
+c     dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,iwf)*dphin(m,iel,1)
+c     dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,iwf)*dphin(m,iel,2)
+c     dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
+                       auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,iwf)*phin(m,iel)
+                       auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+                       auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,iwf)*dphin(m,iel,2)
+                       auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,iwf)*dphin(m,iel,3)
                     enddo
                  enddo
-               enddo
+                 orbn(1:norb,k)=auxorbn
+                 dorbn(1:norb,:,k)=auxdorbn
+              enddo
 
                
             endif

--- a/src/vmc/orbitals.f
+++ b/src/vmc/orbitals.f
@@ -268,9 +268,9 @@ c                      ddorb(  iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,iwf)*d2phin
                       auxddorb(iorb)=auxddorb(iorb)+coef(m,iorb,iwf)*d2phin( m,i)
                    enddo
                 enddo
-                orb(i,1:(norb+nadorb),k)=auxorb(1:(norb+nadorb))
-                dorb(1:(norb+nadorb),i,1:3,k)=auxdorb(1:(norb+nadorb),1:3)
-                ddorb(1:(norb+nadorb),i,k)=auxddorb(1:(norb+nadorb))
+                orb(i,1:norb+nadorb,k)=auxorb
+                dorb(1:norb+nadorb,i,:,k)=auxdorb
+                ddorb(1:norb+nadorb,i,k)=auxddorb
              enddo
           enddo
 #else
@@ -301,9 +301,9 @@ c     ddorb(iorb,i,k)=ddorb(iorb,i,k)+coef(m,iorb,iwf)*d2phin( m,i)
                       auxddorb(iorb)=auxddorb(iorb)+coef(m,iorb,iwf)*d2phin( m,i)
                    enddo
                 enddo
-                orb(i,1:(norb+nadorb),k)=auxorb(1:(norb+nadorb))
-                dorb(1:(norb+nadorb),i,1:3,k)=auxdorb(1:(norb+nadorb),1:3)
-                ddorb(1:(norb+nadorb),i,k)=auxddorb(1:(norb+nadorb))
+                orb(i,1:norb+nadorb,k)=auxorb
+                dorb(1:norb+nadorb,i,:,k)=auxdorb
+                ddorb(1:norb+nadorb,i,k)=auxddorb
              enddo
           enddo
 #endif
@@ -588,9 +588,9 @@ c     ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,iwf)*d2phin(m,iel)
                         auxddorbn(iorb)=auxddorbn(iorb)+coef(m,iorb,iwf)*d2phin(m,iel)
                      enddo
                   enddo
-                    orbn(1:norb,k)=auxorbn(1:norb)
-                    dorbn(1:norb,1:3,k)=auxdorbn(1:norb,1:3)
-                    ddorbn(1:norb,k)=auxddorbn(1:norb)
+                    orbn(1:norb,k)=auxorbn
+                    dorbn(1:norb,:,k)=auxdorbn
+                    ddorbn(1:norb,k)=auxddorbn
                enddo
                
                
@@ -616,8 +616,8 @@ c     dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
                         auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,iwf)*dphin(m,iel,3)
                      enddo
                   enddo
-                  orbn(1:norb,k)=auxorbn(1:norb)
-                  dorbn(1:norb,1:3,k)=auxdorbn(1:norb,1:3)
+                  orbn(1:norb,k)=auxorbn
+                  dorbn(1:norb,:,k)=auxdorbn
                 enddo
                
 
@@ -654,10 +654,9 @@ c     ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,iwf)*d2phin(m,iel)
                         auxddorbn(iorb)=auxddorbn(iorb)+coef(m,iorb,iwf)*d2phin(m,iel)
                     enddo
                  enddo
-                 orbn(1:norb,k)=auxorbn(1:norb)
-                 dorbn(1:norb,1:3,k)=auxdorbn(1:norb,1:3)
-                 ddorbn(1:norb,k)=auxddorbn(1:norb)
-
+                 orbn(1:norb,k)=auxorbn
+                 dorbn(1:norb,:,k)=auxdorbn
+                 ddorbn(1:norb,k)=auxddorbn                 
                enddo
 
 
@@ -684,8 +683,8 @@ c     dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,iwf)*dphin(m,iel,3)
                         auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,iwf)*dphin(m,iel,3)
                      enddo
                   enddo
-                  orbn(1:norb,k)=auxorbn(1:norb)
-                  dorbn(1:norb,1:3,k)=auxdorbn(1:norb,1:3)
+                  orbn(1:norb,k)=auxorbn
+                  dorbn(1:norb,:,k)=auxdorbn
                enddo
 
                

--- a/src/vmc/orbitals.f
+++ b/src/vmc/orbitals.f
@@ -509,7 +509,13 @@ c-------------------------------------------------------------------------------
       real(dp), dimension(3,*) :: x
       real(dp), dimension(3,nelec,ncent_tot) :: rvec_en
       real(dp), dimension(nelec,ncent_tot) :: r_en
-
+      real(dp), dimension(:), allocatable :: auxorbn !(norb)
+      real(dp), dimension(:, :), allocatable :: auxdorbn !(norb)
+      real(dp), dimension(:), allocatable :: auxddorbn !(norb)
+      if (.not. allocated(auxorbn)) allocate (auxorbn(norb))
+      if (.not. allocated(auxdorbn)) allocate (auxdorbn(norb,3))
+      if (.not. allocated(auxddorbn)) allocate (auxddorbn(norb))
+      
 
 #ifdef QMCKL_FOUND
 c     real(dp), allocatable :: mo_vgl_qmckl(:,:,:)
@@ -635,6 +641,9 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
                if(nwftypeorb.gt.1) then
                   
                   do k=1,nwftypeorb
+                     auxorbn=0.d0
+                     auxdorbn=0.d0
+                     auxddorbn=0.d0
                      do iorb=1,norb
                         orbn(iorb,k)=0.d0
                         dorbn(iorb,1,k)=0.d0
@@ -642,17 +651,28 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
                         dorbn(iorb,3,k)=0.d0
                         ddorbn(iorb,k)=0.d0
                         do m=1,nbasis
-                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
-                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
-                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
-                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
-                           ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,k)*d2phin(m,iel)
+c                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
+c                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
+c                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
+c                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
+c                           ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,k)*d2phin(m,iel)
+                           auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,k)*phin(m,iel)
+                           auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,k)*dphin(m,iel,1)
+                           auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,k)*dphin(m,iel,2)
+                           auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,k)*dphin(m,iel,3)
+                           auxddorbn(iorb)=auxddorbn(iorb)+coef(m,iorb,k)*d2phin(m,iel)
                         enddo
                      enddo
+                     orbn(1:norb,k)=auxorbn
+                     dorbn(1:norb,1:3,k)=auxdorbn
+                     ddorbn(1:norb,k)=auxddorbn
                   enddo
                   
                else
-                  
+
+                  auxorbn=0.d0
+                  auxdorbn=0.d0
+                  auxddorbn=0.d0
                   do iorb=1,norb
                      orbn(iorb,1)=0.d0
                      dorbn(iorb,1,1)=0.d0
@@ -660,14 +680,21 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
                      dorbn(iorb,3,1)=0.d0
                      ddorbn(iorb,1)=0.d0
                      do m=1,nbasis
-                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
-                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
-                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
-                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
-                        ddorbn(iorb,1)=ddorbn(iorb,1)+coef(m,iorb,iwf)*d2phin(m,iel)
+c                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
+c                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+c                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
+c                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
+c                        ddorbn(iorb,1)=ddorbn(iorb,1)+coef(m,iorb,iwf)*d2phin(m,iel)
+                        auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,iwf)*phin(m,iel)
+                        auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+                        auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,iwf)*dphin(m,iel,2)
+                        auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,iwf)*dphin(m,iel,3)
+                        auxddorbn(iorb)=auxddorbn(iorb)+coef(m,iorb,iwf)*d2phin(m,iel)
                      enddo
                   enddo
-                  
+                  orbn(1:norb,1)=auxorbn
+                  dorbn(1:norb,1:3,1)=auxdorbn
+                  ddorbn(1:norb,1)=auxddorbn
                   
                endif
 
@@ -677,34 +704,50 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
                if(nwftypeorb.gt.1) then
                   
                   do k=1,nwftypeorb
+                     auxorbn=0.d0
+                     auxdorbn=0.d0
                      do iorb=1,norb
                         orbn(iorb,k)=0.d0
                         dorbn(iorb,1,k)=0.d0
                         dorbn(iorb,2,k)=0.d0
                         dorbn(iorb,3,k)=0.d0
                         do m=1,nbasis
-                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
-                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
-                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
-                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
+c                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
+c                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
+c                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
+c                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
+                           auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,k)*phin(m,iel)
+                           auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,k)*dphin(m,iel,1)
+                           auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,k)*dphin(m,iel,2)
+                           auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,k)*dphin(m,iel,3)
                         enddo
                      enddo
+                     orbn(1:norb,k)=auxorbn
+                     dorbn(1:norb,1:3,k)=auxdorbn
                   enddo
                   
                else
-                  
+
+                  auxorbn=0.d0
+                  auxdorbn=0.d0
                   do iorb=1,norb
                      orbn(iorb,1)=0.d0
                      dorbn(iorb,1,1)=0.d0
                      dorbn(iorb,2,1)=0.d0
                      dorbn(iorb,3,1)=0.d0
                      do m=1,nbasis
-                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
-                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
-                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
-                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
+c                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
+c                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+c                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
+c                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
+                        auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,iwf)*phin(m,iel)
+                        auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+                        auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,iwf)*dphin(m,iel,2)
+                        auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,iwf)*dphin(m,iel,3)
                      enddo
                   enddo
+                  orbn(1:norb,1)=auxorbn
+                  dorbn(1:norb,1:3,1)=auxdorbn
                   
                endif
                
@@ -722,6 +765,9 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
                if(nwftypeorb.gt.1) then
 
                   do k=1,nwftypeorb
+                     auxorbn=0.d0
+                     auxdorbn=0.d0
+                     auxddorbn=0.d0
                      do iorb=1,norb
                         orbn(iorb,k)=0.d0
                         dorbn(iorb,1,k)=0.d0
@@ -730,17 +776,28 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
                         ddorbn(iorb,k)=0.d0
                         do m0=1,n0_nbasis(iel)
                            m=n0_ibasis(m0,iel)
-                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
-                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
-                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
-                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
-                           ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,k)*d2phin(m,iel)
+c                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
+c                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
+c                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
+c                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
+c                           ddorbn(iorb,k)=ddorbn(iorb,k)+coef(m,iorb,k)*d2phin(m,iel)
+                           auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,k)*phin(m,iel)
+                           auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,k)*dphin(m,iel,1)
+                           auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,k)*dphin(m,iel,2)
+                           auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,k)*dphin(m,iel,3)
+                           auxddorbn(iorb)=auxddorbn(iorb)+coef(m,iorb,k)*d2phin(m,iel)
                         enddo
                      enddo
+                     orbn(1:norb,k)=auxorbn
+                     dorbn(1:norb,1:3,k)=auxdorbn
+                     ddorbn(1:norb,k)=auxddorbn
                   enddo
                   
                else
-                  
+
+                  auxorbn=0.d0
+                  auxdorbn=0.d0
+                  auxddorbn=0.d0
                   do iorb=1,norb
                      orbn(iorb,1)=0.d0
                      dorbn(iorb,1,1)=0.d0
@@ -749,19 +806,25 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
                      ddorbn(iorb,1)=0.d0
                      do m0=1,n0_nbasis(iel)
                         m=n0_ibasis(m0,iel)
-                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
-                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
-                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
-                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
-                        ddorbn(iorb,1)=ddorbn(iorb,1)+coef(m,iorb,iwf)*d2phin(m,iel)
+c                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
+c                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+c                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
+c                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
+c                        ddorbn(iorb,1)=ddorbn(iorb,1)+coef(m,iorb,iwf)*d2phin(m,iel)
+                        auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,iwf)*phin(m,iel)
+                        auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+                        auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,iwf)*dphin(m,iel,2)
+                        auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,iwf)*dphin(m,iel,3)
+                        auxddorbn(iorb)=auxddorbn(iorb)+coef(m,iorb,iwf)*d2phin(m,iel)
                      enddo
                   enddo
-               
+                  orbn(1:norb,1)=auxorbn
+                  dorbn(1:norb,1:3,1)=auxdorbn
+                  ddorbn(1:norb,1)=auxddorbn
+                  
                endif
 
                
-              
-
 
             else
 
@@ -770,6 +833,8 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
 
 
                   do k=1,nwftypeorb
+                     auxorbn=0.d0
+                     auxdorbn=0.d0
                      do iorb=1,norb
                         orbn(iorb,k)=0.d0
                         dorbn(iorb,1,k)=0.d0
@@ -777,16 +842,24 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
                         dorbn(iorb,3,k)=0.d0
                         do m0=1,n0_nbasis(iel)
                            m=n0_ibasis(m0,iel)
-                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
-                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
-                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
-                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
+c                           orbn(iorb,k)=orbn(iorb,k)+coef(m,iorb,k)*phin(m,iel)
+c                           dorbn(iorb,1,k)=dorbn(iorb,1,k)+coef(m,iorb,k)*dphin(m,iel,1)
+c                           dorbn(iorb,2,k)=dorbn(iorb,2,k)+coef(m,iorb,k)*dphin(m,iel,2)
+c                           dorbn(iorb,3,k)=dorbn(iorb,3,k)+coef(m,iorb,k)*dphin(m,iel,3)
+                           auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,k)*phin(m,iel)
+                           auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,k)*dphin(m,iel,1)
+                           auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,k)*dphin(m,iel,2)
+                           auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,k)*dphin(m,iel,3)
                         enddo
                      enddo
+                     orbn(1:norb,k)=auxorbn
+                     dorbn(1:norb,1:3,k)=auxdorbn
                   enddo
                   
                else
 
+                  auxorbn=0.d0
+                  auxdorbn=0.d0
                   do iorb=1,norb
                      orbn(iorb,1)=0.d0
                      dorbn(iorb,1,1)=0.d0
@@ -794,13 +867,19 @@ c     dorbn(iorb,3)=mo_vgl_qmckl(iorb,4,1)
                      dorbn(iorb,3,1)=0.d0
                      do m0=1,n0_nbasis(iel)
                         m=n0_ibasis(m0,iel)
-                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
-                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
-                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
-                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
+c                        orbn(iorb,1)=orbn(iorb,1)+coef(m,iorb,iwf)*phin(m,iel)
+c                        dorbn(iorb,1,1)=dorbn(iorb,1,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+c                        dorbn(iorb,2,1)=dorbn(iorb,2,1)+coef(m,iorb,iwf)*dphin(m,iel,2)
+c                        dorbn(iorb,3,1)=dorbn(iorb,3,1)+coef(m,iorb,iwf)*dphin(m,iel,3)
+                        auxorbn(iorb)=auxorbn(iorb)+coef(m,iorb,iwf)*phin(m,iel)
+                        auxdorbn(iorb,1)=auxdorbn(iorb,1)+coef(m,iorb,iwf)*dphin(m,iel,1)
+                        auxdorbn(iorb,2)=auxdorbn(iorb,2)+coef(m,iorb,iwf)*dphin(m,iel,2)
+                        auxdorbn(iorb,3)=auxdorbn(iorb,3)+coef(m,iorb,iwf)*dphin(m,iel,3)
                      enddo
                   enddo
-                                    
+                  orbn(1:norb,1)=auxorbn
+                  dorbn(1:norb,1:3,1)=auxdorbn
+                                       
                endif
 
                


### PR DESCRIPTION
This changes are implemented to improve vectorization for the orbitals subroutines, since a  performance regression has been observed and it is more noticeable when using no vectorization flags for the specific arquitectures. I will wait for the CI tests to pass, then merge it if all is right.. 