### PR TITLE
Intel LLVM compiler support added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
 
 # Project's name
-project(CHAMP VERSION 2.3.0 LANGUAGES Fortran CXX C)
+project(CHAMP VERSION 2.3.0 LANGUAGES Fortran C)
 
 
 # Needed for something which we don't know
@@ -169,7 +169,7 @@ find_package(SystemInfo)
 find_package(GitInfo)
 gitinfo(${CMAKE_SOURCE_DIR})
 
-## Compiler FLAGS
+# List of Fortran flags for Nvidia's NVHPC compiler begins here
 if(CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC")
   list(APPEND Fortran_FLAGS "-O2" "-cpp" "-mcmodel=medium")
   list(APPEND Fortran_FLAGS "-D_MPI_")
@@ -193,9 +193,10 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC")
     list(APPEND Fortran_FLAGS "-m64")
   endif()
 endif()
+# List of Fortran flags for Nvidia's NVHPC compiler ends here
 
 
-## Compiler FLAGS
+# List of Fortran flags for GNU compiler begins here
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
   list(APPEND Fortran_FLAGS "-O2" "-cpp" "-mcmodel=large" "-ffree-line-length-none")
   list(APPEND Fortran_FLAGS "-D_MPI_")
@@ -224,9 +225,10 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     #list(APPEND Fortran_FLAGS "-fdefault-integer-8")
     list(APPEND Fortran_FLAGS "-m64")
   endif()
-  #set(CMAKE_Fortran_FORMAT_FREE_FLAG "-ffree-form")
+  # List of Fortran flags for GNU compiler ends here
 
-elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+# List of Fortran flags for Intel's ifort compiler begins here
+elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
   list(APPEND Fortran_FLAGS "-O2")
   list(APPEND Fortran_FLAGS "-fPIC")
   list(APPEND Fortran_FLAGS "-implicitnone")
@@ -236,21 +238,32 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
   list(APPEND Fortran_FLAGS "-DCLUSTER")
   if(CMAKE_BUILD_TYPE MATCHES "DEBUG")
     list(APPEND Fortran_FLAGS "-O0" "-diag-enable=all" "-traceback" "-g" "-check" "all" )
-    #list(APPEND Fortran_FLAGS "-O0" "-diag-enable=all" "-traceback" "-g" "-check" "bounds" )
   else()
   endif()
   if (TREXIO_FOUND)
     list(APPEND Fortran_FLAGS "-ltrexio")
   endif()
+  set(CMAKE_Fortran_FORMAT_FIXED_FLAG "-free")
+  # List of Fortran flags for Intel's ifort compiler ends here
 
-  set(CMAKE_Fortran_FORMAT_FIXED_FLAG "-fixed -132")
-  #if (MKL_FOUND)
-  #    list(APPEND Fortran_FLAGS "-i8")
-  #endif()
-
-  # debug
-  # list(APPEND Fortran_FLAGS "-g" "-debug" "all" "-traceback")
-
+# List of Fortran flags for Intel's LLVM based compiler begins here
+elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
+  list(APPEND Fortran_FLAGS "-O2")
+  list(APPEND Fortran_FLAGS "-fPIC")
+  list(APPEND Fortran_FLAGS "-implicitnone")
+  list(APPEND Fortran_FLAGS "-finline" "-align" "array64byte" "-fma" "-ftz" "-fomit-frame-pointer")
+	list(APPEND Fortran_FLAGS "-fpp" "-mcmodel=small" "-shared-intel" "-dyncom=grid3d_data,orbital_num_spl,orbital_num_lag,orbital_num_spl2,grid3d_data" )
+  list(APPEND Fortran_FLAGS "-D_MPI_")
+  list(APPEND Fortran_FLAGS "-DCLUSTER")
+  if(CMAKE_BUILD_TYPE MATCHES "DEBUG")
+    list(APPEND Fortran_FLAGS "-O0" "-diag-enable=all" "-traceback" "-g" "-check" "all" )
+  else()
+  endif()
+  if (TREXIO_FOUND)
+    list(APPEND Fortran_FLAGS "-ltrexio")
+  endif()
+  set(CMAKE_Fortran_FORMAT_FIXED_FLAG "-free")
+  # List of Fortran flags for Intel's LLVM based compiler ends here
 
 elseif(Fortran_COMPILER_ID MATCHES "PGI")
   list(APPEND CMAKE_Fortran_FLAGS "-Mfreeform -Mdclchk -Mstandard -Mallocatable=03")

--- a/compile-gnu
+++ b/compile-gnu
@@ -1,2 +1,3 @@
+#!/bin/bash
 cmake -H. -B build -DCMAKE_Fortran_COMPILER=/usr/bin/mpif90
-cmake --build build 
+cmake --build build

--- a/compile-intel
+++ b/compile-intel
@@ -1,2 +1,9 @@
-cmake -S. -Bbuild -DCMAKE_Fortran_COMPILER=mpiifort
-cmake --build build
+#!/bin/bash
+
+MPIFC='mpiifort'    # OR 'mpiifx'   Intel's LLVM based compiler
+
+cmake -S. -Bbuild \
+    -DCMAKE_Fortran_COMPILER=${MPIFC}
+
+cmake --build build -j
+

--- a/compile-intel.qmckl
+++ b/compile-intel.qmckl
@@ -1,10 +1,20 @@
-#install trexio with hdf5 
-#install qmckl linked to trexio
-#set or replace the directories  regarding your installation 
-trexio_dir=''
-qmckl_dir=''
+#!/bin/bash
+# Install trexio with hdf5
+# Install qmckl linked to trexio
+# Set the library paths according to your installation
 
-cmake -S. -Bbuild -DCMAKE_Fortran_COMPILER=mpiifort  -DENABLE_QMCKL=ON -DBLAS_LIBRARIES="-qmkl=parallel"  -DQMCKL_FOUND="TRUE" -DQMCKL_INCLUDE_DIR=${qmckl_dir}/include -DQMCKL_LIBRARY=${qmckl_dir}/lib/libqmckl.so -DENABLE_TREXIO=ON -DTREXIO_FOUND="TRUE" -DTREXIO_INCLUDE_DIR=${trexio_dir}/include -DTREXIO_LIBRARY=${trexio_dir}/lib/libtrexio.so -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON 
+compiler=''             # 'mpiifort' or 'mpiifx'
+trexio_dir=''           # Root directory of TREXIO library
+qmckl_dir=''            # Root directory of QMCkl library
 
-cmake --build build
+cmake -S. -Bbuild \
+    -DCMAKE_Fortran_COMPILER=${compiler} \
+    -DENABLE_TREXIO=ON \
+    -DTREXIO_INCLUDE_DIR=${trexio_dir}/include \
+    -DTREXIO_LIBRARY=${trexio_dir}/lib/libtrexio.so \
+    -DENABLE_QMCKL=ON \
+    -DQMCKL_INCLUDE_DIR=${qmckl_dir}/include \
+    -DQMCKL_LIBRARY=${qmckl_dir}/lib/libqmckl.so \
+
+cmake --build build -j
 

--- a/compile-nvfortran
+++ b/compile-nvfortran
@@ -1,3 +1,5 @@
+#!/bin/bash
+# The following modules work on Snellius
 module load 2022
 module load CMake/3.23.1-GCCcore-11.3.0
 module load OpenMPI/4.1.4-NVHPC-22.7-CUDA-11.7.0
@@ -6,5 +8,6 @@ cmake -H. -B build \
     -DCMAKE_Fortran_COMPILER=mpif90 \
     -DCMAKE_C_COMPILER=mpicc \
     -DENABLE_GPU=ON \
-    -DNVFORTRAN_PATH=/sw/arch/RHEL8/EB_production/2022/software/NVHPC/22.7-CUDA-11.7.0/Linux_x86_64/22.7/compilers/bin
+    -DNVFORTRAN_PATH=${NVHPC}/Linux_x86_64/22.7/compilers/bin
+
 cmake --build build -j 12


### PR DESCRIPTION
CHAMP is compiled using Intel's latest LLVM-based compilers - mpiifx and mpiifc (2024.0).

Some cleanup of existing compile scripts