### PR TITLE
Fujitsu compiler support added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,17 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC")
 endif()
 # List of Fortran flags for Nvidia's NVHPC compiler ends here
 
+# List of Fortran flags for Fujitsu compiler begins here
+if(CMAKE_Fortran_COMPILER_ID MATCHES "Fujitsu")
+  message(STATUS "Fujitsu compiler detected :: ")
+  list(APPEND Fortran_FLAGS "-O3" "-Cpp" "-Nalloc_assign" "-Fwide" "-fs" "-Kopenmp" "-Kparallel" "-Kfast" "-mcmodel=large" )
+  list(APPEND Fortran_FLAGS "-D_MPI_")
+  list(APPEND Fortran_FLAGS "-DCLUSTER")
+  if (TREXIO_FOUND)
+     list(APPEND Fortran_FLAGS "-L${TREXIO_LIBRARY} -ltrexio -I${TREXIO_INCLUDE_DIR}")
+  endif()
+endif()
+# List of Fortran flags for Fujitsu compiler ends here
 
 # List of Fortran flags for GNU compiler begins here
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")

--- a/compile-fujitsu
+++ b/compile-fujitsu
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Load the following modules on Fugaku Supercomputer
+. /vol0004/apps/oss/spack/share/spack/setup-env.sh
+spack load cmake@3.24.3%fj@4.8.1/p5qsrqc
+spack load fujitsu-mpi@head%fj@4.8.1
+spack load hdf5@1.12.2%fj@4.8.1/tpglq6h
+spack load fujitsu-ssl2@head%fj@4.8.1/nndozbk
+
+MPIFC='mpifrt'    # Fujitsu Fortran compiler
+MPICC='mpifcc'    # Fujitsu C compiler
+
+cmake -S. -Bbuild \
+    -DCMAKE_Fortran_COMPILER=${MPIFC} \
+    -DCMAKE_C_COMPILER=${MPICC}
+
+cmake --build build -j
+

--- a/src/dmc/CMakeLists.txt
+++ b/src/dmc/CMakeLists.txt
@@ -59,7 +59,7 @@ target_compile_options(dmc.mov1
   "$<$<CONFIG:Debug>:${Fortan_FLAGS_DEBUG}>"
   )
 
-  if(CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC")
+  if(CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC" OR CMAKE_Fortran_COMPILER_ID MATCHES "Fujitsu")
   	target_link_options(dmc.mov1
 	  PRIVATE
 	  ${Fortran_FLAGS}

--- a/src/vmc/CMakeLists.txt
+++ b/src/vmc/CMakeLists.txt
@@ -373,7 +373,7 @@ ENDIF()
     "$<$<CONFIG:Debug>:${Fortan_FLAGS_DEBUG}>"
     )
 
-  if(CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC")    
+  if(CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC" OR CMAKE_Fortran_COMPILER_ID MATCHES "Fujitsu")
      target_link_options(vmc.mov1
        PRIVATE
        ${Fortran_FLAGS}


### PR DESCRIPTION
Fujitsu compiler support added for CHAMP:

- Code now compiles on A64FX (Fugaku Supercomputer) with Fujitsu compilers
- Sample compilation script along with required spack modules added