### PR TITLE
Fix initialization of pathak

### DIFF
--- a/src/vmc/acuest.f90
+++ b/src/vmc/acuest.f90
@@ -134,7 +134,6 @@ contains
       call pcm_init(1)
       call mmpol_init(1)
       call force_analy_init(1)
-      if(ipathak.gt.0) call init_eps_pathak()
 
       call acuest_reduce(enow)
 
@@ -232,6 +231,7 @@ contains
       call mmpol_init(0)
       call force_analy_init(0)
       call efficiency_init
+      if(ipathak.gt.0) call init_eps_pathak()
 
       do ifr=1,nforce
         do istate=1,nstates


### PR DESCRIPTION
Pathak for VMC initialized each block, but it should only happen once at the beginning of a run. This fixes the issue.