### PR TITLE
Add shebangs to CI test scripts

### DIFF
--- a/tests/CI_test/DMC-C4H6-ci1010_pVTZ-500-dets/DMC_C4H6_ci1010_pVTZ_500-dets_butadiene.sh
+++ b/tests/CI_test/DMC-C4H6-ci1010_pVTZ-500-dets/DMC_C4H6_ci1010_pVTZ_500-dets_butadiene.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "Butadiene DMC 500 dets "
 
 input="dmc.inp"

--- a/tests/CI_test/DMC-TREXIO-water-DFT-jas2body_tau0.05/DMC_TREXIO_H2O_DFT_2body_tau0.05_water.sh
+++ b/tests/CI_test/DMC-TREXIO-water-DFT-jas2body_tau0.05/DMC_TREXIO_H2O_DFT_2body_tau0.05_water.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "TREXIO DMC water 2body jastrow tau=0.05  "
 
 input="vmc_h2o_dft_jas2body.inp"

--- a/tests/CI_test/VMC-C4H6-ci1010_pVTZ-00500-dets/VMC_C4H6_ci1010_pVTZ_500-dets_butadiene_optimization.sh
+++ b/tests/CI_test/VMC-C4H6-ci1010_pVTZ-00500-dets/VMC_C4H6_ci1010_pVTZ_500-dets_butadiene_optimization.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "VMC butadiene ci1010 pVTZ 500 determinants"
 
 input="vmc_optimization_500.inp"

--- a/tests/CI_test/VMC-C4H6-ci1010_pVTZ-05000-dets/VMC_C4H6_ci1010_pVTZ_5000-dets_butadiene_optimization.sh
+++ b/tests/CI_test/VMC-C4H6-ci1010_pVTZ-05000-dets/VMC_C4H6_ci1010_pVTZ_5000-dets_butadiene_optimization.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "VMC butadiene ci1010 pVTZ 5000 determinants"
 
 input="vmc_optimization_5000.inp"

--- a/tests/CI_test/VMC-C4H6-ci1010_pVTZ-15000-dets/VMC_C4H6_ci1010_pVTZ_15000-dets_butadiene_optimization.sh
+++ b/tests/CI_test/VMC-C4H6-ci1010_pVTZ-15000-dets/VMC_C4H6_ci1010_pVTZ_15000-dets_butadiene_optimization.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "VMC butadiene ci1010 pVTZ 15000 determinants"
 
 input="vmc_optimization_15000.inp"

--- a/tests/CI_test/VMC-C4H6-ci44_pVQZ_20_dets_12_csf_noopt/VMC_C4H6_ci44_pVQZ_20-dets_12-csf_energy-only_butadiene.sh
+++ b/tests/CI_test/VMC-C4H6-ci44_pVQZ_20_dets_12_csf_noopt/VMC_C4H6_ci44_pVQZ_20-dets_12-csf_energy-only_butadiene.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "VMC butadiene ci44 pVQZ energy only"
 
 input="vmc_noopt_ci44.inp"

--- a/tests/CI_test/VMC-C4H6-ci44_pVQZ_20_dets_12_csf_optall/VMC_C4H6_ci44_pVQZ_20-dets_12-csf_optimization_butadiene.sh
+++ b/tests/CI_test/VMC-C4H6-ci44_pVQZ_20_dets_12_csf_optall/VMC_C4H6_ci44_pVQZ_20-dets_12-csf_optimization_butadiene.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "VMC butadiene ci44 pVQZ all optimizations "
 
 input="vmc_optall_ci44.inp"

--- a/tests/CI_test/VMC-C4H6-ras1022_Q_optWF+geo-64000dets/VMC_C4H6_ras1022_SDT_pVQZ_geometry_optimization_64000-dets_butadiene.sh
+++ b/tests/CI_test/VMC-C4H6-ras1022_Q_optWF+geo-64000dets/VMC_C4H6_ras1022_SDT_pVQZ_geometry_optimization_64000-dets_butadiene.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "Butadiene optimization 65000 determinants "
 
 input="vmc_opt_ras1022_pVQZ_65000.inp"

--- a/tests/CI_test/VMC-H2/VMC_H2_STO-CVB1_corsamp_hydrogen.sh
+++ b/tests/CI_test/VMC-H2/VMC_H2_STO-CVB1_corsamp_hydrogen.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "H2 energy with corsamp method"
 
 input="revised_vmc_corsamp.inp"

--- a/tests/CI_test/VMC-H2/VMC_H2_STO-CVB1_energy_hydrogen.sh
+++ b/tests/CI_test/VMC-H2/VMC_H2_STO-CVB1_energy_hydrogen.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "H2 energy with sr_n method"
 
 input="revised_vmc.inp"

--- a/tests/CI_test/VMC-HNO-cipsi_322_dets_143_csfs_noopt/VMC-HNO-cipsi_322_dets_143_csfs_noopt.sh
+++ b/tests/CI_test/VMC-HNO-cipsi_322_dets_143_csfs_noopt/VMC-HNO-cipsi_322_dets_143_csfs_noopt.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "VMC nitroxyl cipsi 322 dets energy only"
 
 input="vmc.inp"

--- a/tests/CI_test/VMC-HNO-cipsi_322_dets_143_csfs_optall/VMC-HNO-cipsi_322_dets_143_csfs_optall.sh
+++ b/tests/CI_test/VMC-HNO-cipsi_322_dets_143_csfs_optall/VMC-HNO-cipsi_322_dets_143_csfs_optall.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "VMC nitroxyl cipsi 322 dets full optimization"
 
 input="vmc.inp"

--- a/tests/CI_test/VMC-PSB2-36_dets-20_csfs_ci44_BFD-Da/VMC-PSB2-36_dets-20_csfs_ci44_mixn.sh
+++ b/tests/CI_test/VMC-PSB2-36_dets-20_csfs_ci44_BFD-Da/VMC-PSB2-36_dets-20_csfs_ci44_mixn.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "PSB2 with mix_n method"
 
 input="revised_psb2_mix_n.inp"

--- a/tests/CI_test/VMC-TREXIO-CH2O-excited-8724-dets-BFD-aug-cc-pVDZ/VMC_TREXIO_CH2O_excited_8724-dets_BFD-aug-cc-pVDZ_formaldehyde_energy.sh
+++ b/tests/CI_test/VMC-TREXIO-CH2O-excited-8724-dets-BFD-aug-cc-pVDZ/VMC_TREXIO_CH2O_excited_8724-dets_BFD-aug-cc-pVDZ_formaldehyde_energy.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "TREXIO formaldehyde excited state energy"
 
 input="trexio_vmc_COH2_excited_state.inp"

--- a/tests/CI_test/VMC-TREXIO-H2O-3body-Jastrow/VMC_TREXIO_H2O_3body_jastrow_water.sh
+++ b/tests/CI_test/VMC-TREXIO-H2O-3body-Jastrow/VMC_TREXIO_H2O_3body_jastrow_water.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "TREXIO water 3body Jastrow"
 
 input="vmc.inp"

--- a/tests/CI_test/VMC-TREXIO-H2O-DFT-optall/VMC_TREXIO_H2O_DFT_optimization_water.sh
+++ b/tests/CI_test/VMC-TREXIO-H2O-DFT-optall/VMC_TREXIO_H2O_DFT_optimization_water.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "TREXIO water optimization"
 
 input="vmc_h2o_dft_optall.inp"

--- a/tests/CI_test/VMC-TREXIO-QMCKL-C2H6O-optorb/VMC_TREXIO_QMCKL_C2H6O_ethanol_optimization.sh
+++ b/tests/CI_test/VMC-TREXIO-QMCKL-C2H6O-optorb/VMC_TREXIO_QMCKL_C2H6O_ethanol_optimization.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "QMCKL + TREXIO VMC ethanol orbital optimization "
 
 input="vmc_ethanol_opt.inp"

--- a/tests/CI_test/VMC-TREXIO-text-hdf5-backend-comparison/VMC_TREXIO_text_hdf5_backend_comparison_butadiene_energy_ci1010_pVTZ.sh
+++ b/tests/CI_test/VMC-TREXIO-text-hdf5-backend-comparison/VMC_TREXIO_text_hdf5_backend_comparison_butadiene_energy_ci1010_pVTZ.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "TREXIO backend comparison: HDF5"
 input="vmc_opt_ci1010_pVTZ_1522_hdf5.inp"
 output="vmc_opt_ci1010_pVTZ_1522_hdf5"

--- a/tests/CI_test/VMC-TREXIO-text-hdf5-backend-comparison/hdf5.sh
+++ b/tests/CI_test/VMC-TREXIO-text-hdf5-backend-comparison/hdf5.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "TREXIO backend comparison: HDF5"
 input="vmc_opt_ci1010_pVTZ_1522_hdf5.inp"
 output="vmc_opt_ci1010_pVTZ_1522_hdf5"

--- a/tests/CI_test/VMC-TREXIO-text-hdf5-backend-comparison/text.sh
+++ b/tests/CI_test/VMC-TREXIO-text-hdf5-backend-comparison/text.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "TREXIO backend comparison : TEXT"
 input="vmc_opt_ci1010_pVTZ_1522_text.inp"
 output="vmc_opt_ci1010_pVTZ_1522_text"

--- a/tests/CI_test/VMC-jas1-Hlattice-force_analy/VMC-jas1-Hlattice-force_analy.sh
+++ b/tests/CI_test/VMC-jas1-Hlattice-force_analy/VMC-jas1-Hlattice-force_analy.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "periodic H lattice Jastrow 1"
 
 input="vmc.inp"


### PR DESCRIPTION
Adds a `#!/bin/bash` shebang to 21 CI test scripts (codex-work commit 2c1f2291).

_Part of splitting the codex-work branch into independent, easily-mergeable PRs. **Source-only — contains no CMake changes** (those are in the CMake-overhaul PR #335). Touches files that no other split PR touches, so it merges independently in any order._

🤖 Generated with [Claude Code](https://claude.com/claude-code)