### PR TITLE
Initialize dormant external-potential flags

### DIFF
--- a/src/module/m_input.f90
+++ b/src/module/m_input.f90
@@ -44,7 +44,7 @@ module inputflags
     integer :: node_cutoff, dmc_node_cutoff
     real(dp) :: eps_node_cutoff, dmc_eps_node_cutoff
     real(dp) :: scalecoef
-    integer :: iqmmm
+    integer :: iqmmm = 0
  ! dmc specifics:
     real(dp) :: enode_cutoff
     integer :: icircular

--- a/src/module/m_mmpol.f90
+++ b/src/module/m_mmpol.f90
@@ -12,11 +12,11 @@ end module mmpol_mod
 module mmpol_cntrl
     !> Arguments: isites_mmpol, immpolprt, icall_mm, ich_mmpol, immpol
 
-    integer :: icall_mm
-    integer :: ich_mmpol
-    integer :: immpol
-    integer :: immpolprt
-    integer :: isites_mmpol
+    integer :: icall_mm = 0
+    integer :: ich_mmpol = 0
+    integer :: immpol = 0
+    integer :: immpolprt = 0
+    integer :: isites_mmpol = 0
 
     private
     public :: isites_mmpol, immpolprt, icall_mm, ich_mmpol, immpol

--- a/src/module/m_pcm.f90
+++ b/src/module/m_pcm.f90
@@ -123,11 +123,11 @@ end module pcm_averages
 module pcm_cntrl
     !> Arguments: ichpol, ipcm, ipcmprt, icall, isurf
 
-    integer :: icall
-    integer :: ichpol
-    integer :: ipcm
-    integer :: ipcmprt
-    integer :: isurf
+    integer :: icall = 0
+    integer :: ichpol = 0
+    integer :: ipcm = 0
+    integer :: ipcmprt = 0
+    integer :: isurf = 0
 
     private
     public :: ichpol, ipcm, ipcmprt, icall, isurf


### PR DESCRIPTION
Initializes dormant external-potential flags in m_input/m_mmpol/m_pcm (codex-work commit 829c383a). A small correctness fix.

_Part of splitting the codex-work branch into independent, easily-mergeable PRs. **Source-only — contains no CMake changes** (those are in the CMake-overhaul PR #335). Touches files that no other split PR touches, so it merges independently in any order._

🤖 Generated with [Claude Code](https://claude.com/claude-code)