### PR TITLE
Avoid global iwf mutation in determinant psit routines

### DIFF
--- a/src/vmc/determinant_psit.f90
+++ b/src/vmc/determinant_psit.f90
@@ -9,17 +9,16 @@ contains
       use vmc_mod, only: stoo, nwftypeorb
       implicit none
 
-      integer :: istate, k, iwf_save, o
+      integer :: istate, k, kcdet, o
       real(dp) :: determ
 
       determ=0.0d0
-      iwf_save=iwf
       o=stoo(istate)
-      if(nwftypeorb.gt.1) iwf=1
+      kcdet=iwf
+      if(nwftypeorb.gt.1) kcdet=1
       do k=1,ndet
-        determ=determ+detiab(k,1,o)*detiab(k,2,o)*cdet(k,istate,iwf)
+        determ=determ+detiab(k,1,o)*detiab(k,2,o)*cdet(k,istate,kcdet)
       enddo
-      iwf=iwf_save
 
 
       return

--- a/src/vmc/determinante_psit.f90
+++ b/src/vmc/determinante_psit.f90
@@ -12,24 +12,24 @@ contains
       use vmc_mod, only: stoo, nwftypeorb
       implicit none
 
-      integer :: iel, istate, k, iwf_save, o
-      real(dp) :: det, determ
+      integer :: iel, istate, iab_other, k, kcdet, o
+      real(dp) :: determ
 
       o=stoo(istate)
-      iwf_save=iwf
 
-      if(nwftypeorb.gt.1) iwf=1
-      determ=0.d0
+      kcdet=iwf
+      if(nwftypeorb.gt.1) kcdet=1
+
       if(iel.le.nup) then
-       do k=1,ndet
-          determ=determ+detn(k,o)*detiab(k,2,o)*cdet(k,istate,iwf)
-       enddo
+        iab_other=2
       else
-         do k=1,ndet
-            determ=determ+detn(k,o)*detiab(k,1,o)*cdet(k,istate,iwf)
-         enddo
+        iab_other=1
       endif
-      iwf=iwf_save
+
+      determ=0.d0
+      do k=1,ndet
+         determ=determ+detn(k,o)*detiab(k,iab_other,o)*cdet(k,istate,kcdet)
+      enddo
 
       return
       end


### PR DESCRIPTION
Avoids mutating the global `iwf` in determinant_psit/determinante_psit (codex-work commit 99ab7345). A correctness fix.

_Part of splitting the codex-work branch into independent, easily-mergeable PRs. **Source-only — contains no CMake changes** (those are in the CMake-overhaul PR #335). Touches files that no other split PR touches, so it merges independently in any order._

🤖 Generated with [Claude Code](https://claude.com/claude-code)