### PR TITLE
Synchronize CHAMP version references (m_control)

### DIFF
--- a/src/module/m_control.f90
+++ b/src/module/m_control.f90
@@ -383,7 +383,10 @@ contains
 
 
         implicit none
-        character(len=40), parameter            :: VERSION = 'v2.0.0'
+#ifndef CHAMP_VERSION
+#define CHAMP_VERSION "unknown"
+#endif
+        character(len=*), parameter             :: VERSION = CHAMP_VERSION
         character(len=80), allocatable          :: arg(:)
         integer                                 :: i, j, iostat, argcount
         character(len=10), dimension(12)        :: extensions


### PR DESCRIPTION
Source slice of codex-work commits 070c566d/7b8b7e1b: m_control.f90 gains a CHAMP_VERSION fallback and uses the macro for VERSION. The CMake/version-metadata half lives in PR #335 (which defines CHAMP_VERSION); this compiles standalone via the fallback.

_Part of splitting the codex-work branch into independent, easily-mergeable PRs. **Source-only — contains no CMake changes** (those are in the CMake-overhaul PR #335). Touches files that no other split PR touches, so it merges independently in any order._

🤖 Generated with [Claude Code](https://claude.com/claude-code)