### PR TITLE
Clean VMC outer bookkeeping

### DIFF
--- a/src/vmc/fin_reduce.f90
+++ b/src/vmc/fin_reduce.f90
@@ -3,7 +3,6 @@ contains
       subroutine fin_reduce
 ! MPI version written by Claudia Filippi
 
-      use control_vmc, only: vmc_nstep
       use csfs,    only: nstates
       use custom_broadcast, only: bcast
       use est2cm,  only: ecm21
@@ -15,7 +14,7 @@ contains
       use mmpol_reduce_mod, only: mmpol_reduce
       use mmpol_vmc, only: mmpol_fin
       use mpi
-      use mpiconf, only: nproc,wid
+      use mpiconf, only: wid
       use mstates_mod, only: MSTATES
       use multiple_geo, only: nforce
       use optci_mod, only: optci_fin
@@ -37,9 +36,8 @@ contains
 
       implicit none
 
-      integer :: i, id, ierr, istate
-      integer, dimension(MPI_STATUS_SIZE) :: istatus
-      real(dp) :: dble, efin, passes
+      integer :: ierr, istate
+      real(dp) :: efin
       real(dp), dimension(MSTATES) :: collect
 
       call mpi_reduce(ecum1,collect,nstates,mpi_double_precision,mpi_sum,0,MPI_COMM_WORLD,ierr)
@@ -76,22 +74,7 @@ contains
 
       call bcast(ecum1)
       call bcast(wcum)
-!       if(wid) then
-!         do 60 id=1,nproc-1
-!           call mpi_send(ecum1,nstates,mpi_double_precision,id
-!      &    ,1,MPI_COMM_WORLD,ierr)
-! c    &    ,1,MPI_COMM_WORLD,irequest,ierr)
-!    60     call mpi_send(wcum,nstates*nforce,mpi_double_precision,id
-!      &    ,2,MPI_COMM_WORLD,ierr)
-! c    &    ,2,MPI_COMM_WORLD,irequest,ierr)
-!        else
-!         call mpi_recv(ecum1,nstates,mpi_double_precision,0
-!      &  ,1,MPI_COMM_WORLD,istatus,ierr)
-!         call mpi_recv(wcum,nstates*nforce,mpi_double_precision,0
-!      &  ,2,MPI_COMM_WORLD,istatus,ierr)
-!       endif
 
-      passes=dble(iblk)*dble(vmc_nstep)
       efin=ecum1(1)/wcum(1,1)
 
       call optjas_fin(wcum(1,1),ecum1)
@@ -107,9 +90,6 @@ contains
 
         call optx_orb_ci_fin(wcum(1,1),efin)
       endif
-
-!     call efficiency_prt(passes)
-
 ! reduce pcm properties
       call pcm_reduce
 

--- a/src/vmc/mc_configs.f90
+++ b/src/vmc/mc_configs.f90
@@ -1,31 +1,15 @@
 module mc_configs
 
-      use config,  only: xnew,xold
-      use contrl_file, only: errunit,ounit
-      use control_vmc, only: vmc_icharged_atom,vmc_irstar,vmc_isite
-      use control_vmc, only: vmc_nconf_new
-      use error,   only: fatal_error
-      use fin_reduce_mod, only: fin_reduce
       use mpi
-      use system, only: znuc, iwctype, ncent, ncent_tot, nelec
       use config, only: xnew, xold
-      use mpiconf, only: idtask, nproc
-!use contrl, only: irstar, isite, nconf_new, icharged_atom
       use control_vmc, only: vmc_irstar, vmc_isite, vmc_nconf_new, vmc_icharged_atom
-      use contrl_file,    only: ounit, errunit
-      use precision_kinds, only: dp
-      use random_mod, only: savern, setrn, random_dp
-      use sites_mod, only: sites
+      use contrl_file, only: ounit
       use error, only: fatal_error
-      use pcm_mod, only: pcm_qvol
       use fin_reduce_mod, only: fin_reduce
       use mpiconf, only: idtask,nproc
       use pcm_mod, only: pcm_qvol
-      use precision_kinds, only: dp
-      use random_mod, only: random_dp,savern,setrn
       use sites_mod, only: sites
       use system,  only: iwctype,ncent,ncent_tot,nelec,znuc
-!use contrl, only: irstar, isite, nconf_new, icharged_atom
 
       implicit none
 
@@ -33,72 +17,67 @@ contains
       subroutine mc_configs_start
       implicit none
 
-      integer :: i, ic, icharge_system, id, ierr
-      integer :: index, k, l, ntotal_sites
-      integer, dimension(8) :: irn
+      integer :: i, icharge_system, id
+      integer :: ierr
+      integer :: k, l, ntotal_sites
       integer, dimension(ncent_tot) :: nsite
-      integer, dimension(MPI_STATUS_SIZE) :: istatus
-      integer, dimension(8) :: irn_temp
-      real(dp) :: err, rnd
       character(len=64) filename
       character(len=32) :: cnum
+      logical :: configs_file_open
+      logical :: use_sites
 
-! set the random number seed differently on each processor
-! call to setrn must be in read_input since irn local there
-! 
-! Victor: 2023 In the parser the seed is now set differently on each processor
-!         thus doing it here again should not be necessary
+! The parser already sets a different random seed on each processor.
       if(vmc_irstar.ne.1) then
 
-!       if(nproc.gt.1) then
-!         do id=1,(3*nelec)*idtask
-!           rnd=random_dp()
-!         enddo
-!         call savern(irn)
-!         do i=1,8
-!           irn(i)=mod(irn(i)+int(random_dp()*idtask*9999),9999)
-!         enddo
-!         call setrn(irn)
-!       endif
+        use_sites = vmc_isite.eq.1
+        if (.not.use_sites) then
+          open(unit=9,iostat=ierr,file='mc_configs_start')
+          use_sites = ierr.ne.0
+        endif
 
-! check sites flag if one gets initial configuration from sites routine
-        if (vmc_isite.eq.1) goto 20
-        open(unit=9,err=20,file='mc_configs_start')
-        rewind 9
-        do id=0,idtask
-          read(9,*,end=20,err=20) ((xold(k,i),k=1,3),i=1,nelec)
-        enddo
-        write(ounit,'(/,''initial configuration from unit 9'')')
-        goto 40
+        if (.not.use_sites) then
+          rewind 9
+          do id=0,idtask
+            read(9,*,iostat=ierr) ((xold(k,i),k=1,3),i=1,nelec)
+            if (ierr.ne.0) then
+              use_sites = .true.
+              close(9)
+              exit
+            endif
+          enddo
+        endif
 
-      20   continue
-        ntotal_sites=0
-        do i=1,ncent
-          ntotal_sites=ntotal_sites+int(znuc(iwctype(i))+0.5d0)
-        enddo
-        icharge_system=ntotal_sites-nelec
+        if (.not.use_sites) then
+          write(ounit,'(/,''initial configuration from unit 9'')')
+        else
+! Generate the initial configuration from atomic sites.
+          ntotal_sites=0
+          do i=1,ncent
+            ntotal_sites=ntotal_sites+int(znuc(iwctype(i))+0.5d0)
+          enddo
+          icharge_system=ntotal_sites-nelec
 
-        l=0
-        do i=1,ncent
-          nsite(i)=int(znuc(iwctype(i))+0.5d0)
-          if (vmc_icharged_atom.eq.i) then
-            nsite(i)=int(znuc(iwctype(i))+0.5d0)-icharge_system
-            if (nsite(i).lt.0) call fatal_error('MC_CONFIG: error in icharged_atom')
-          endif
-          l=l+nsite(i)
-          if (l.gt.nelec) then
-            nsite(i)=nsite(i)-(l-nelec)
-            l=nelec
-          endif
-        enddo
-        if (l.lt.nelec) nsite(1)=nsite(1)+(nelec-l)
+          l=0
+          do i=1,ncent
+            nsite(i)=int(znuc(iwctype(i))+0.5d0)
+            if (vmc_icharged_atom.eq.i) then
+              nsite(i)=int(znuc(iwctype(i))+0.5d0)-icharge_system
+              if (nsite(i).lt.0) call fatal_error('MC_CONFIG: error in icharged_atom')
+            endif
+            l=l+nsite(i)
+            if (l.gt.nelec) then
+              nsite(i)=nsite(i)-(l-nelec)
+              l=nelec
+            endif
+          enddo
+          if (l.lt.nelec) nsite(1)=nsite(1)+(nelec-l)
 
-        call sites(xold,nelec,nsite)
-        open(unit=9,file='mc_configs_start')
-        rewind 9
+          call sites(xold,nelec,nsite)
+          open(unit=9,file='mc_configs_start')
+          rewind 9
 
-        write(ounit,'(/,''initial configuration from sites'')')
-      40   continue
+          write(ounit,'(/,''initial configuration from sites'')')
+        endif
 
 ! If we are moving one electron at a time, then we need to initialize
 ! xnew, since only the first electron gets initialized in metrop
@@ -109,10 +88,11 @@ contains
         enddo
       endif
 
+      inquire(unit=9, opened=configs_file_open)
+      if (.not.configs_file_open) open(unit=9,file='mc_configs_start')
+
 ! If nconf_new > 0 then we want to dump configurations for a future
-! optimization or dmc calculation. So figure out how often we need to write a
-! configuration to produce nconf_new configurations. If nconf_new = 0
-! then set up so no configurations are written.
+! optimization or dmc calculation.
       if (vmc_nconf_new.gt.0) then
         write(cnum,*) idtask
         filename='mc_configs_new'//trim(adjustl(cnum))

--- a/src/vmc/vmc.f90
+++ b/src/vmc/vmc.f90
@@ -9,10 +9,9 @@ contains
 
       use acuest_mod, only: acuest,zerest
       use config,  only: eold,psido,psijo,xold
-      use contrl_file, only: ounit
       use control, only: mode
       use control_vmc, only: vmc_idump,vmc_irstar,vmc_nblk,vmc_nblkeq
-      use control_vmc, only: vmc_nconf,vmc_nconf_new,vmc_nstep
+      use control_vmc, only: vmc_nconf_new,vmc_nstep
       use dumper_mod, only: dumper,startr
       use error, only: fatal_error
       use finwrt_mod, only: finwrt
@@ -24,7 +23,6 @@ contains
       use metropolis, only: imetro
       use mpitimer, only: elapsed_time
       use multiple_geo, only: iwftype,nforce,nwftype
-      use precision_kinds, only: dp
       use pseudo,  only: nloc
       use rotqua_mod, only: rotqua
       use strech_mod, only: setup_force
@@ -42,7 +40,6 @@ contains
 
       integer :: i, ii, j, jj, l
       integer :: ngfmc
-      real(dp) ::err
       character(len=8)  :: date
       character(len=10) :: time
       integer           :: hdf5_restart_funit, hdf5_restart_ios


### PR DESCRIPTION
Cherry-pick of codex-work 07c7b8fb (fin_reduce/mc_configs/vmc.f90). vmc.f90 reconciled with main HDF5: keeps the HDF5 restart declarations, drops the unused `err` declaration and now-dead use statements. Builds verified.

_Part of splitting the codex-work branch into independent, easily-mergeable PRs. **Source-only — contains no CMake changes** (those are in the CMake-overhaul PR #335). Touches files that no other split PR touches, so it merges independently in any order._

🤖 Generated with [Claude Code](https://claude.com/claude-code)