### PR TITLE
Check the HDF5 restart against an uninterrupted run

### DIFF
--- a/tests/CI_test/VMC-HDF5-restart-CH2O-excited-BFD-aug-cc-pVDZ/run1.inp
+++ b/tests/CI_test/VMC-HDF5-restart-CH2O-excited-BFD-aug-cc-pVDZ/run1.inp
@@ -1,5 +1,5 @@
 %module general
-    title           'COH2 Formaldehyde VMC excited state - HDF5 restart test (restore phase)'
+    title           'COH2 Formaldehyde VMC excited state - HDF5 restart test (uninterrupted reference)'
     pool            './pool/'
     mode            'vmc_one_mpi'
     ipr -1
@@ -16,10 +16,9 @@ load jastrow_der     jastrow.der
 %endmodule
 
 %module blocking_vmc
-    vmc_irstar    1
     vmc_idump     0
     vmc_nstep     20
-    vmc_nblk      500
-    vmc_nblkeq    0
+    vmc_nblk      10
+    vmc_nblkeq    1
     vmc_nconf_new 0
 %endmodule

--- a/tests/CI_test/VMC-HDF5-restart-CH2O-excited-BFD-aug-cc-pVDZ/run2.inp
+++ b/tests/CI_test/VMC-HDF5-restart-CH2O-excited-BFD-aug-cc-pVDZ/run2.inp
@@ -18,7 +18,7 @@ load jastrow_der     jastrow.der
 %module blocking_vmc
     vmc_idump     1
     vmc_nstep     20
-    vmc_nblk      500
+    vmc_nblk      5
     vmc_nblkeq    1
     vmc_nconf_new 0
 %endmodule

--- a/tests/CI_test/VMC-HDF5-restart-CH2O-excited-BFD-aug-cc-pVDZ/run3.inp
+++ b/tests/CI_test/VMC-HDF5-restart-CH2O-excited-BFD-aug-cc-pVDZ/run3.inp
@@ -1,0 +1,25 @@
+%module general
+    title           'COH2 Formaldehyde VMC excited state - HDF5 restart test (restore phase)'
+    pool            './pool/'
+    mode            'vmc_one_mpi'
+    ipr -1
+%endmodule
+
+load trexio          COH2_ES.trexio
+
+load jastrow         jastrow.start
+load jastrow_der     jastrow.der
+
+%module electrons
+    nup           6
+    nelec         12
+%endmodule
+
+%module blocking_vmc
+    vmc_irstar    1
+    vmc_idump     0
+    vmc_nstep     20
+    vmc_nblk      5
+    vmc_nblkeq    0
+    vmc_nconf_new 0
+%endmodule

--- a/tests/CI_test/VMC-HDF5-restart-CH2O-excited-BFD-aug-cc-pVDZ/test.json
+++ b/tests/CI_test/VMC-HDF5-restart-CH2O-excited-BFD-aug-cc-pVDZ/test.json
@@ -1,5 +1,5 @@
 {
-  "description": "HDF5 checkpoint/restart for VMC: step1 runs 500 blocks and dumps the full state, step2 restores and runs 500 more; the cumulative energy over all 1000 blocks must match the reference",
+  "description": "HDF5 checkpoint/restart for VMC: run1 is an uninterrupted 10-block run; run2 covers the first 5 blocks from scratch and dumps the state, run3 restores it and runs the remaining 5. Both paths must produce exactly the same cumulative energy -- the absolute value is irrelevant, only that a restart reproduces the uninterrupted run bit for bit.",
   "labels": [
     "VMC",
     "HDF5",
@@ -13,35 +13,62 @@
   "cases": [
     {
       "name": "np2",
+      "comment": "run1 and run2 must start from exactly the same walker configuration, so the mc_configs_start each run leaves behind is removed before both of them; only run3 is allowed to inherit state, and only through the HDF5 checkpoint.",
       "runs": [
         {
           "program": "vmc",
-          "input": "step1.inp",
-          "output": "step1_core_2.out",
+          "input": "run1.inp",
+          "output": "run1_core_2.out",
           "nproc": 2,
-          "error_output": "error_step1"
+          "error_output": "error_run1",
+          "before": [
+            {
+              "op": "remove",
+              "paths": [
+                "mc_configs_start",
+                "restart_vmc*"
+              ]
+            }
+          ]
         },
         {
           "program": "vmc",
-          "input": "step2.inp",
-          "output": "step2_core_2.out",
+          "input": "run2.inp",
+          "output": "run2_core_2.out",
           "nproc": 2,
-          "error_output": "error_step2"
+          "error_output": "error_run2",
+          "before": [
+            {
+              "op": "remove",
+              "paths": [
+                "mc_configs_start",
+                "restart_vmc*"
+              ]
+            }
+          ]
+        },
+        {
+          "program": "vmc",
+          "input": "run3.inp",
+          "output": "run3_core_2.out",
+          "nproc": 2,
+          "error_output": "error_run3"
         }
       ],
       "checks": [
         {
           "type": "file_exists",
           "file": "restart_vmc.hdf5",
-          "comment": "checkpoint written by step1"
+          "comment": "checkpoint written by run2"
         },
         {
-          "type": "value",
-          "file": "step2_core_2.out",
+          "type": "values_equal",
+          "files": [
+            "run3_core_2.out",
+            "run1_core_2.out"
+          ],
           "match": "total E",
-          "value": -22.6202928,
-          "error": 0.0058981,
-          "comment": "cumulative energy over 1000 blocks"
+          "comment": "5 blocks + restart + 5 blocks must reproduce the uninterrupted 10 blocks exactly"
         }
       ]
     }


### PR DESCRIPTION
## Problem

`VMC-HDF5-restart-CH2O-excited-BFD-aug-cc-pVDZ` ran 500 blocks, dumped the state, restored it and ran 500 more, then compared the cumulative energy to a hard-coded `-22.6202928 +- 0.0058981`.


## Change

Compute the reference instead of storing it.

| file | role |
|---|---|
| `run1.inp` (new) | from scratch, 20 x 10 blocks, `vmc_idump 0` -- the uninterrupted reference |
| `run2.inp` (was `step1.inp`) | from scratch, 20 x 5, `vmc_idump 1` -- writes the checkpoint |
| `run3.inp` (was `step2.inp`) | `vmc_irstar 1`, 20 x 5 -- restores and finishes |

`test.json` runs all three and replaces the `value` check with `values_equal` on `total E` between `run3_core_2.out` and `run1_core_2.out`. Splitting a run in half and resuming has to reproduce the whole run exactly, so the check is exact equality and there is no reference number left to age. 10 blocks is enough to demonstrate it; the case drops from minutes to about 1.5 s.

## The mc_configs_start guard

Every run ends with `mc_configs_write`, which writes `mc_configs_start`, and `mc_configs_start` reads that file at startup (`src/vmc/mc_configs.f90:34`). Run 2 would otherwise begin where run 1 stopped rather than where run 1 started, breaking the premise that the two paths sample the same trajectory. A `before: remove` op clears `mc_configs_start` (and `restart_vmc*`) ahead of both from-scratch runs; only run 3 inherits state, and only through the checkpoint.

On the build used here the leftover file happens not to be picked up -- both runs report "initial configuration from sites" either way -- so the guard is not load-bearing today. It is kept because that `open` succeeding is compiler- and runtime-dependent, and this invariant is what the test rests on.

## Verification

Built with gfortran/OpenMPI + TREXIO + QMCkl + HDF5 and run through `champ_test_runner.py`: **PASS, 2/2 checks**.

```
[check 2/2] values of 'total E' equal in run3_core_2.out and run1_core_2.out
    run3_core_2.out : -22.5725388 +- 0.0441503
    run1_core_2.out : -22.5725388 +- 0.0441503
    PASS
```

Exact agreement, error bars included.

Negative control: re-running `run3.inp` with `vmc_irstar 0` in the same scratch directory gives `-22.7198585 +- 0.0682328`. The check discriminates a broken restart rather than passing trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)