### PR TITLE
Probe for -mcmodel=large instead of hard-coding a platform list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,11 +277,28 @@ endif()
 
 # List of Fortran flags for GNU compiler begins here
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
-  if(APPLE AND CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64")
-    list(APPEND Fortran_FLAGS "-O2" "-cpp" "-ffree-line-length-none")
+  list(APPEND Fortran_FLAGS "-O2" "-cpp" "-ffree-line-length-none")
+
+  # The large code model lifts the 2 GB limit on static data that the default
+  # (small) model imposes on x86-64.  It is not portable: AArch64 gfortran
+  # either rejects it outright ("code model 'large' not supported yet" on
+  # macOS/arm64) or refuses to combine it with position independent code,
+  # which distributions such as Ubuntu enable by default and which CHAMP needs
+  # for its shared libraries.  Probe the compiler with -fPIC in effect instead
+  # of hard-coding a platform list, so the flag is used wherever it works and
+  # silently dropped where it does not (see issue #288).
+  include(CheckFortranCompilerFlag)
+  set(CMAKE_REQUIRED_FLAGS_SAVED "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -fPIC")
+  check_fortran_compiler_flag("-mcmodel=large" CHAMP_Fortran_HAS_MCMODEL_LARGE)
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS_SAVED}")
+  unset(CMAKE_REQUIRED_FLAGS_SAVED)
+  if(CHAMP_Fortran_HAS_MCMODEL_LARGE)
+    list(APPEND Fortran_FLAGS "-mcmodel=large")
   else()
-    list(APPEND Fortran_FLAGS "-O2" "-cpp" "-mcmodel=large" "-ffree-line-length-none")
+    message(STATUS "-mcmodel=large is not supported together with -fPIC :: using the default code model")
   endif()
+
   if(CMAKE_BUILD_TYPE MATCHES "^[Dd][Ee][Bb][Uu][Gg]$")
     list(APPEND Fortran_FLAGS "-fcheck=all" "-fbacktrace"
         "-g" "-Wall" "-Wextra" "-fPIC"

--- a/docs/users/getting_started/installation/dependencies/compilers.md
+++ b/docs/users/getting_started/installation/dependencies/compilers.md
@@ -40,7 +40,10 @@ brew install gcc
 
 - `-O2` - Optimization level 2
 - `-cpp` - Enable preprocessor
-- `-mcmodel=large` - Large memory model support
+- `-mcmodel=large` - Large memory model support, added only when the compiler
+  accepts it together with `-fPIC`. On AArch64 (ARM64) targets, including Apple
+  Silicon and ARM Linux, gfortran rejects that combination, so CHAMP configures
+  the default code model instead
 - `-ffree-line-length-none` - No limit on free-form line length
 - `-D_MPI_` and `-DCLUSTER` - MPI and cluster support
 


### PR DESCRIPTION
Fixes #288.

## The problem

GNU builds passed `-mcmodel=large` unconditionally except on Apple Silicon, which had been special-cased earlier. ARM Linux still got the flag and still failed at the first `src/parser` source:

```
f951: sorry, unimplemented: code model 'large' with '-fPIC'
```

The issue suggests dropping `-fPIC`, but that alone would not fix it — `-fPIC` is unavoidable on that platform for two independent reasons:

- Ubuntu's gcc is built with `--enable-default-pie`, so PIC is on even with no flag passed. Plain `-mcmodel=large` with no other flags reproduces the error.
- CHAMP builds `src/parser` (and `vmc` under `UNIT_TESTS`) as a **shared** library, so CMake adds `-fPIC` on its own regardless of what we put in `Fortran_FLAGS`.

The large code model is what has to go on AArch64, not `-fPIC`.

## The change

`CMakeLists.txt` now asks the compiler rather than guessing from the platform. The probe runs with `-fPIC` in `CMAKE_REQUIRED_FLAGS`, so it tests the exact combination the build actually uses; the flag is kept where it works and dropped with a status message where it does not. This also subsumes the existing Apple Silicon special case, where gfortran reports the large model as unimplemented outright, so the hard-coded `APPLE AND arm64` branch is gone.

Docs updated to describe the flag as conditional.

## Verification

The reporter's environment reproduced in Docker — Ubuntu 22.04 aarch64, GCC 11.4.0, matching the versions in the issue:

| Platform | Before | After |
|---|---|---|
| Linux aarch64 | build exit 2, `sorry, unimplemented: code model 'large' with '-fPIC'` | configures without the flag, full build to `vmc.mov1` / `dmc.mov1` / `libparser.so` |
| Linux x86_64 | `-mcmodel=large` applied | probe succeeds, `-mcmodel=large` still applied |
| macOS arm64 | worked via the special case | works via the probe, ctest **30/30 passed** |

The x86-64 row is the regression check that matters: nothing changes on the platform CHAMP normally builds on.

I also confirmed the probe is not a check that always fails — under identical conditions `-mcmodel=small` and `-ffree-line-length-none` both come back Success while `-mcmodel=large` fails.

## For the reviewer

Unrelated to this fix, but noticed while tracing where `-fPIC` comes from: `src/vmc/CMakeLists.txt:393` builds `vmc SHARED` from `OBJECT` libraries that never get `POSITION_INDEPENDENT_CODE` set. The explicit `-fPIC` in the GNU Debug-only flag list looks like a workaround for exactly that, which would mean `-DUNIT_TESTS=ON` in a Release build could hit relocation errors on Linux x86-64. I could not trigger it here and left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)