### PR TITLE
Allow the analytic force file to be named from the input

### DIFF
--- a/docs/users/preparation/input/outputs_keywords.md
+++ b/docs/users/preparation/input/outputs_keywords.md
@@ -1,0 +1,76 @@
+---
+title: Outputs Keywords
+tags:
+    - input
+    - outputs
+    - keywords
+    - forces
+---
+
+# Output File Keywords
+
+The `%module outputs` block names the optional files a run writes. Every keyword
+in it has a default, so the block itself is optional: leaving it out reproduces
+the file names CHAMP has always used.
+
+Its purpose is to keep concurrent runs from writing over each other. A VMC and a
+DMC calculation started in the same directory both write their analytic forces
+to `force_analytic` unless they are told otherwise, and whichever finishes last
+wins.
+
+```perl
+%module outputs
+    file_force_analytic  'force_vmc.dat'
+%endmodule
+```
+
+## The `outputs` module
+
+<div class="grid cards single-col" markdown>
+
+-   __Analytic force file__
+
+    ---
+
+    Name of the file the analytic forces are written to at the end of a VMC or
+    DMC run. Only written when `iforce_analy 1` is set in `%module general`.
+    Include the extension you want; the name is used verbatim, relative to the
+    working directory. Quotes are optional.
+
+    Default: `force_analytic`
+
+    ```perl
+    file_force_analytic  'force_dmc.dat'
+    ```
+
+</div>
+
+## Running VMC and DMC in the same directory
+
+Give each run its own name and both sets of forces survive:
+
+```perl
+# vmc.inp
+%module general
+    title           'butadiene forces'
+    mode            'vmc_one_mpi'
+    iforce_analy     1
+%endmodule
+
+%module outputs
+    file_force_analytic  'force_vmc.dat'
+%endmodule
+```
+
+```perl
+# dmc.inp
+%module general
+    title           'butadiene forces'
+    mode            'dmc_one_mpi1'
+    iforce_analy     1
+%endmodule
+
+%module outputs
+    file_force_analytic  'force_dmc.dat'
+%endmodule
+```

--- a/docs/users/workflows/molecular/dmc_forces.md
+++ b/docs/users/workflows/molecular/dmc_forces.md
@@ -22,4 +22,18 @@ To enable force calculations, you typically need to:
 %endmodule
 ```
 
+## Output file
+
+The forces are written to `force_analytic` in the working directory. Name the
+file yourself when more than one run shares a directory -- a VMC and a DMC run,
+say -- so that they do not overwrite each other:
+
+```perl
+%module outputs
+    file_force_analytic  'force_dmc.dat'
+%endmodule
+```
+
+[:octicons-arrow-right-24: Outputs Keywords](../../preparation/input/outputs_keywords.md)
+
 *Check `tests/CI_test/VMC-C4H6-ci44_pVQZ_20_dets_12_csf_optall/vmc_optall_ci44.inp` for VMC force examples, which often translate to DMC.*

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -80,7 +80,8 @@ nav = [
     ]},
     {"Input File Examples" = [
       {"Input Files Overview" = "preparation/input/index.md"},
-      {"General Keywords" = "preparation/input/general_keywords.md"}
+      {"General Keywords" = "preparation/input/general_keywords.md"},
+      {"Outputs Keywords" = "preparation/input/outputs_keywords.md"}
     ]}
   ]},  
   {"Calculations" = [

--- a/src/module/CMakeLists.txt
+++ b/src/module/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SHARED_MODULES
     m_allocation.f90
     m_state_avrg.f90
     m_error.f90
+    m_outputs.f90
     m_qmckl.F90
     ${CMAKE_PARSER_DIR}/fdf.F90
     ${CMAKE_PARSER_DIR}/io_fdf.F90

--- a/src/module/m_outputs.f90
+++ b/src/module/m_outputs.f90
@@ -1,0 +1,24 @@
+!> @brief Names of the optional output files written by CHAMP.
+!> @details The names collected here are read from the `%module outputs`
+!> section of the input file. Giving each run its own set of output file
+!> names makes it possible to run, for instance, a VMC and a DMC
+!> calculation in the same directory without one overwriting the results
+!> of the other.
+module outputs
+
+    implicit none
+
+    !> Maximum length of a user-specified output file name
+    integer, parameter :: MAX_FILENAME_LENGTH = 80
+
+    !> Name of the file with the analytic forces written by force_analy_fin.
+    !> Set with the `file_force_analytic` keyword of the `%module outputs`
+    !> input section.
+    character(len=MAX_FILENAME_LENGTH) :: file_force_analytic = 'force_analytic'
+
+    private
+    public :: MAX_FILENAME_LENGTH
+    public :: file_force_analytic
+    save
+
+end module outputs

--- a/src/parser/fdf.F90
+++ b/src/parser/fdf.F90
@@ -123,15 +123,15 @@ module keywords
   !> @email r.l.shinde@utwente.nl
   !> @date October 15, 2022
   implicit none
-  integer                     :: num_modules  = 11   ! change this number after every adition/deletion
-  integer                     :: num_keywords = 190 ! change this number after every adition/deletion
+  integer                     :: num_modules  = 12   ! change this number after every adition/deletion
+  integer                     :: num_keywords = 191 ! change this number after every adition/deletion
 
   type :: string_t
     character(:), allocatable    :: keys
   end type string_t
 
-  type(string_t) allowed_modules(11)
-  type(string_t) allowed_keywords(190)       ! change this number after every adition/deletion
+  type(string_t) allowed_modules(12)
+  type(string_t) allowed_keywords(191)       ! change this number after every adition/deletion
 
 
   private
@@ -239,7 +239,8 @@ module keywords
     allowed_keywords(183)%keys = 'istrech';         allowed_keywords(184)%keys = 'alfastr'
     allowed_keywords(185)%keys = 'nfrag';           allowed_keywords(186)%keys = 'ibranching_cfrag'
     allowed_keywords(187)%keys = 'etrialfrag';      allowed_keywords(188)%keys = 'use_qmckl_jastrow'
-    allowed_keywords(189)%keys = 'use_qmckl_orbitals';allowed_keywords(190)%keys = 'f_analy_err';
+    allowed_keywords(189)%keys = 'use_qmckl_orbitals';allowed_keywords(190)%keys = 'f_analy_err'
+    allowed_keywords(191)%keys = 'file_force_analytic';
 
   end subroutine allocate_keywords
 
@@ -255,6 +256,7 @@ module keywords
       allowed_modules(9)%keys  = 'blocking_dmc'
       allowed_modules(10)%keys = 'mstates'
       allowed_modules(11)%keys = 'properties'
+      allowed_modules(12)%keys = 'outputs'
   end subroutine allocate_modulenames
 
 
@@ -378,7 +380,7 @@ MODULE fdf
   USE prec
   implicit none
 
-  character(len=40)  :: modulenames(10)
+  character(len=40)  :: modulenames(20)
   integer            :: number_of_modules = 0
 ! User callable routines in FDF library
 

--- a/src/vmc/force_analytic.f90
+++ b/src/vmc/force_analytic.f90
@@ -512,6 +512,7 @@ contains
       use m_force_analytic, only: da_energy_ave, iforce_analy
       use m_force_analytic, only: da_psi_block, wcum_block, da_energy_psi_block
       use m_force_analytic, only: wcum_block, f_analy_err
+      use outputs, only: file_force_analytic
       use precision_kinds, only: dp
       use system,  only: ncent
       use vd_mod, only: dmc_ivd, da_branch_cum
@@ -555,7 +556,7 @@ contains
         enddo
       endif
 
-      open(80,file='force_analytic',form='formatted',status='unknown')
+      open(80,file=trim(file_force_analytic),form='formatted',status='unknown')
       do iph=1,PTH
         do ic=1,ncent
           do k=1,3

--- a/src/vmc/parser.f90
+++ b/src/vmc/parser.f90
@@ -99,6 +99,7 @@ subroutine parser
       use optwf_handle_wf, only: set_nparms_tot
       use optwf_parms, only: nparmj
       use orbval,  only: nadorb
+      use outputs, only: file_force_analytic
       use mpi
       use pathak_mod, only: ipathak, eps_max, deps
       use pathak_mod, only: init_pathak, init_eps_pathak
@@ -330,6 +331,12 @@ subroutine parser
     alfgeo      = fdf_get('alfgeo', 1.0d0)
   endif
   iroot_geo   = fdf_get('iroot_geo', 0)
+
+! Output file names
+  file_force_analytic = adjustl(fdf_get('file_force_analytic', 'force_analytic'))
+  ! A keyword given without a value parses as an empty string; keep the default
+  ! rather than trying to open a file with no name.
+  if (len_trim(file_force_analytic) .eq. 0) file_force_analytic = 'force_analytic'
 
 ! Numerical gradient options
   delgrdxyz   = fdf_get('delgrdxyz', 0.001d0)
@@ -1498,6 +1505,11 @@ subroutine parser
       write(ounit,'(a,t36,f12.6)') " starting alfgeo = ", alfgeo
       if(nstates.gt.1) write(ounit,'(a,i3)' ) " Following state ",iroot_geo
     endif
+  endif
+
+  ! Name of the file the analytic forces are written to (vmc and dmc)
+  if(iforce_analy.gt.0) then
+    write(ounit, string_format) " Analytic forces written to ", trim(file_force_analytic)
   endif
 
   if (ipathak.gt.0) call init_eps_pathak()

--- a/tests/CI_test/VMC-jas1-Hlattice-force_analy/test.json
+++ b/tests/CI_test/VMC-jas1-Hlattice-force_analy/test.json
@@ -33,6 +33,30 @@
           "comment": "analytic forces within 2 sigma of reference"
         }
       ]
+    },
+    {
+      "name": "np2-named-force-file",
+      "comment": "Same calculation with the force file renamed through %module outputs: the forces have to come out of force_vmc_named.dat instead of the default force_analytic, and be the same numbers.",
+      "runs": [
+        {
+          "program": "vmc",
+          "input": "vmc_named_force_file.inp",
+          "output": "vmc_named.out",
+          "nproc": 2
+        }
+      ],
+      "checks": [
+        {
+          "type": "file_exists",
+          "file": "force_vmc_named.dat"
+        },
+        {
+          "type": "forces",
+          "file": "force_vmc_named.dat",
+          "reference": "force_reference",
+          "comment": "analytic forces written to the user-named file"
+        }
+      ]
     }
   ]
 }

--- a/tests/CI_test/VMC-jas1-Hlattice-force_analy/vmc_named_force_file.inp
+++ b/tests/CI_test/VMC-jas1-Hlattice-force_analy/vmc_named_force_file.inp
@@ -1,0 +1,66 @@
+%module general
+    title           'Test LiF - named force file'
+    pool            './pool/'
+    pseudopot        ECP
+    basis	           BASISGRID
+    mode            'vmc_one_mpi'
+    imetro           1
+    ijas             1
+    nspin2          -2
+    ipr     		    -1
+    sample           0
+
+    iforce_analy     1
+    iperiodic        1
+    np_coul          2
+    npoly            7
+    cutg             3.847717423927704
+    cutg_big         11.61929355981926
+    n_images         2
+%endmodule
+
+%block lattice
+  7.67421   0.0   0.0  
+   0.0  7.67421   0.0  
+   0.0   0.0  7.67421  
+%endblock
+
+load molecule        geo
+
+load basis_num_info  $pool/basis_pointers.bfinfo
+
+load determinants    determinant.det
+load orbitals        orbitals_optimal
+load jastrow         jastrow_optimal
+
+%module electrons
+    nup           4
+    nelec         8
+%endmodule
+
+%module optwf
+    ioptwf        0
+    ioptci        0
+    ioptjas       0
+    ioptorb       0
+    method        'sr_n'
+    ncore         0
+    nextorb       400
+    nblk_max      200   
+    no_active     0
+    nopt_iter     20
+    sr_tau        0.05
+    sr_eps        0.01 
+    sr_adiag      0.001 
+%endmodule
+
+%module blocking_vmc
+    vmc_nstep     20
+    vmc_nblk      200
+    vmc_nblkeq    1 
+    vmc_nconf_new 0 
+%endmodule
+
+%module outputs
+    file_force_analytic  'force_vmc_named.dat'
+%endmodule


### PR DESCRIPTION
This closes #287 raised by @EmielSlootman.

A run always wrote its analytic forces to a file literally called force_analytic, so a VMC and a DMC calculation started in the same directory could overwrite each other's results.

Add a %module outputs input section holding the names of the optional files a run produces, with file_force_analytic as its first keyword:

    %module outputs
        file_force_analytic  'force_analytic_vmc.txt'
    %endmodule

The name is read into the new `outputs` Fortran module for both VMC and DMC. It defaults to force_analytic, so existing inputs are unaffected; a keyword given without a value falls back to the default rather than trying to open a file with no name.

The keyword and the module name are registered in the parser's approved lists (src/parser/fdf.F90). modulenames is grown from 10 to 20 entries: there were already 11 allowed module names, so an input using all of them would have overrun the array.

Covered by a new np2-named-force-file case on
VMC-jas1-Hlattice-force_analy, which asserts the renamed file is produced and that its forces still match the committed reference.

@EmielSlootman Please check if the name "file_force_analytic" is informative enough. 