### PR TITLE
CI: Node 24 action runtimes, path-scoped workflows, HDF5 caching, TREXIO 2.6.1 and ubuntu-26.04

### DIFF
--- a/.github/actions/champ-test-values/action.yml
+++ b/.github/actions/champ-test-values/action.yml
@@ -56,7 +56,7 @@ runs:
 
     - name: Upload the measured values
       if: steps.values.outputs.measured == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.artifact-name }}
         if-no-files-found: warn

--- a/.github/workflows/build_champ_intel.yml
+++ b/.github/workflows/build_champ_intel.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         toolchain: ['intel']
     name: Build CHAMP with ${{ matrix.toolchain }} OneAPI GitHub-hosted runner
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 300
     defaults:
       run:

--- a/.github/workflows/build_champ_intel.yml
+++ b/.github/workflows/build_champ_intel.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         toolchain: ['intel']
     name: Build CHAMP with ${{ matrix.toolchain }} OneAPI GitHub-hosted runner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 300
     defaults:
       run:

--- a/.github/workflows/build_champ_intel.yml
+++ b/.github/workflows/build_champ_intel.yml
@@ -8,10 +8,26 @@ on:
     tags:
       - v2.*.*
       - v3.*.*
+    # Documentation and the Python tooling each have a workflow of their
+    # own; a change confined to them has nothing to build here.  Path
+    # filters are not evaluated for tag pushes, so a release is still
+    # built and tested in full.
+    paths-ignore:
+      - 'docs/**'
+      - 'tools/trex_tools/**'
+      - '**.md'
+      - '.github/workflows/build_documentation_devel.yml'
+      - '.github/workflows/test_python.yml'
   pull_request:
     branches:
       - 'releases/**'
       - main
+    paths-ignore:
+      - 'docs/**'
+      - 'tools/trex_tools/**'
+      - '**.md'
+      - '.github/workflows/build_documentation_devel.yml'
+      - '.github/workflows/test_python.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_champ_intel.yml
+++ b/.github/workflows/build_champ_intel.yml
@@ -44,7 +44,7 @@ jobs:
           sudo apt-get install -y intel-oneapi-compiler-fortran
 
       - name: Get the CHAMP code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/build_champ_intel.yml
+++ b/.github/workflows/build_champ_intel.yml
@@ -8,10 +8,6 @@ on:
     tags:
       - v2.*.*
       - v3.*.*
-    # Documentation and the Python tooling each have a workflow of their
-    # own; a change confined to them has nothing to build here.  Path
-    # filters are not evaluated for tag pushes, so a release is still
-    # built and tested in full.
     paths-ignore:
       - 'docs/**'
       - 'tools/trex_tools/**'

--- a/.github/workflows/build_champ_qmckl.yml
+++ b/.github/workflows/build_champ_qmckl.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         toolchain: ['GNU']
     name: Build CHAMP/TREXIO/QMCkl with ${{ matrix.toolchain }} (QMCKL Tests)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 200
     defaults:
       run:

--- a/.github/workflows/build_champ_qmckl.yml
+++ b/.github/workflows/build_champ_qmckl.yml
@@ -8,10 +8,26 @@ on:
     tags:
       - v2.*.*
       - v3.*.*
+    # Documentation and the Python tooling each have a workflow of their
+    # own; a change confined to them has nothing to build here.  Path
+    # filters are not evaluated for tag pushes, so a release is still
+    # built and tested in full.
+    paths-ignore:
+      - 'docs/**'
+      - 'tools/trex_tools/**'
+      - '**.md'
+      - '.github/workflows/build_documentation_devel.yml'
+      - '.github/workflows/test_python.yml'
   pull_request:
     branches:
       - 'releases/**'
       - main
+    paths-ignore:
+      - 'docs/**'
+      - 'tools/trex_tools/**'
+      - '**.md'
+      - '.github/workflows/build_documentation_devel.yml'
+      - '.github/workflows/test_python.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_champ_qmckl.yml
+++ b/.github/workflows/build_champ_qmckl.yml
@@ -30,6 +30,11 @@ on:
       - '.github/workflows/test_python.yml'
   workflow_dispatch:
 
+env:
+  # The one HDF5 the source-building workflows share; bump it here and the
+  # cache key follows.
+  HDF5_VERSION: 1.14.2
+
 jobs:
   build_champ_qmckl:
     strategy:
@@ -53,14 +58,52 @@ jobs:
           which python
           python --version
 
-      - name: Build HDF5 from source
+      # HDF5 is by a wide margin the slowest thing in this job, and what it
+      # produces depends only on the version and on the compilers that build
+      # it, so the installed tree is cached.  Fortran .mod files are tied to
+      # the exact gfortran that wrote them, so the key carries the compiler
+      # versions: a new runner image invalidates the cache instead of
+      # handing the build modules it cannot read.
+      - name: Identify the toolchain the HDF5 cache is keyed on
+        id: toolchain
         run: |
-          wget https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_14_2.tar.gz
-          tar -xzf hdf5-1_14_2.tar.gz
-          cd hdf5-hdf5-1_14_2
-          ./configure FC=mpif90 CC=mpicc FCFLAGS=-O2 CFLAGS=-O2 CXX=mpic++ --enable-parallel --enable-static --enable-shared --enable-fortran --prefix=$HOME
+          set -e
+          {
+            gcc -dumpfullversion
+            gfortran -dumpfullversion
+            mpirun --version | head -n 1
+          } > toolchain.id
+          cat toolchain.id
+          echo "id=$(sha256sum toolchain.id | cut -c 1-12)" >> "$GITHUB_OUTPUT"
+
+      # Staged under a prefix of its own so the cache holds HDF5 and nothing
+      # else: TREXIO -- and, where it is built, QMCkl -- install into $HOME
+      # later in this job, and have versions of their own to track.
+      - name: Restore the HDF5 build
+        id: cache-hdf5
+        uses: actions/cache@v6
+        with:
+          path: ~/hdf5-install
+          key: hdf5-${{ env.HDF5_VERSION }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.id }}
+
+      - name: Build HDF5 from source
+        if: steps.cache-hdf5.outputs.cache-hit != 'true'
+        run: |
+          set -e
+          tag="hdf5-${HDF5_VERSION//./_}"
+          wget -q "https://github.com/HDFGroup/hdf5/archive/refs/tags/${tag}.tar.gz"
+          tar -xzf "${tag}.tar.gz"
+          cd "hdf5-${tag}"
+          ./configure FC=mpif90 CC=mpicc FCFLAGS=-O2 CFLAGS=-O2 CXX=mpic++ --enable-parallel --enable-static --enable-shared --enable-fortran --prefix=$HOME/hdf5-install
           make -j$(nproc)
           make install
+
+      # $HOME is the prefix every later step looks in, cached build or not.
+      - name: Install HDF5 into the dependency prefix
+        run: |
+          set -e
+          cp -a "$HOME/hdf5-install/." "$HOME/"
+          head -n 25 "$HOME/lib/libhdf5.settings"
 
       - name: Clone and Install TREXIO-v2.5.0
         run: |

--- a/.github/workflows/build_champ_qmckl.yml
+++ b/.github/workflows/build_champ_qmckl.yml
@@ -8,10 +8,6 @@ on:
     tags:
       - v2.*.*
       - v3.*.*
-    # Documentation and the Python tooling each have a workflow of their
-    # own; a change confined to them has nothing to build here.  Path
-    # filters are not evaluated for tag pushes, so a release is still
-    # built and tested in full.
     paths-ignore:
       - 'docs/**'
       - 'tools/trex_tools/**'
@@ -31,8 +27,6 @@ on:
   workflow_dispatch:
 
 env:
-  # The one HDF5 the source-building workflows share; bump it here and the
-  # cache key follows.
   HDF5_VERSION: 1.14.2
 
 jobs:
@@ -58,12 +52,6 @@ jobs:
           which python
           python --version
 
-      # HDF5 is by a wide margin the slowest thing in this job, and what it
-      # produces depends only on the version and on the compilers that build
-      # it, so the installed tree is cached.  Fortran .mod files are tied to
-      # the exact gfortran that wrote them, so the key carries the compiler
-      # versions: a new runner image invalidates the cache instead of
-      # handing the build modules it cannot read.
       - name: Identify the toolchain the HDF5 cache is keyed on
         id: toolchain
         run: |
@@ -76,9 +64,6 @@ jobs:
           cat toolchain.id
           echo "id=$(sha256sum toolchain.id | cut -c 1-12)" >> "$GITHUB_OUTPUT"
 
-      # Staged under a prefix of its own so the cache holds HDF5 and nothing
-      # else: TREXIO -- and, where it is built, QMCkl -- install into $HOME
-      # later in this job, and have versions of their own to track.
       - name: Restore the HDF5 build
         id: cache-hdf5
         uses: actions/cache@v6
@@ -98,7 +83,6 @@ jobs:
           make -j$(nproc)
           make install
 
-      # $HOME is the prefix every later step looks in, cached build or not.
       - name: Install HDF5 into the dependency prefix
         run: |
           set -e

--- a/.github/workflows/build_champ_qmckl.yml
+++ b/.github/workflows/build_champ_qmckl.yml
@@ -28,6 +28,7 @@ on:
 
 env:
   HDF5_VERSION: 1.14.2
+  TREXIO_VERSION: 2.6.1
 
 jobs:
   build_champ_qmckl:
@@ -89,11 +90,12 @@ jobs:
           cp -a "$HOME/hdf5-install/." "$HOME/"
           head -n 25 "$HOME/lib/libhdf5.settings"
 
-      - name: Clone and Install TREXIO-v2.5.0
+      - name: Clone and Install TREXIO
         run: |
-          wget https://github.com/TREX-CoE/trexio/releases/download/v2.5.0/trexio-2.5.0.tar.gz
-          tar -xzf trexio-2.5.0.tar.gz
-          cd trexio-2.5.0
+          set -e
+          wget -q "https://github.com/TREX-CoE/trexio/releases/download/v${TREXIO_VERSION}/trexio-${TREXIO_VERSION}.tar.gz"
+          tar -xzf "trexio-${TREXIO_VERSION}.tar.gz"
+          cd "trexio-${TREXIO_VERSION}"
           export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH
           cmake -S. -Bbuild \
             -DCMAKE_Fortran_COMPILER=mpif90 \

--- a/.github/workflows/build_champ_qmckl.yml
+++ b/.github/workflows/build_champ_qmckl.yml
@@ -74,7 +74,7 @@ jobs:
           make install
 
       - name: Clone the CHAMP code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Compile the CHAMP code with TREXIO and QMCkl using GNU compilers and run the QMCKL tests
         run: |

--- a/.github/workflows/build_champ_trexio.yml
+++ b/.github/workflows/build_champ_trexio.yml
@@ -30,6 +30,11 @@ on:
       - '.github/workflows/test_python.yml'
   workflow_dispatch:
 
+env:
+  # The one HDF5 the source-building workflows share; bump it here and the
+  # cache key follows.
+  HDF5_VERSION: 1.14.2
+
 jobs:
   build_champ_trexio:
     strategy:
@@ -53,14 +58,52 @@ jobs:
           which python
           python --version
 
-      - name: Build HDF5 from source
+      # HDF5 is by a wide margin the slowest thing in this job, and what it
+      # produces depends only on the version and on the compilers that build
+      # it, so the installed tree is cached.  Fortran .mod files are tied to
+      # the exact gfortran that wrote them, so the key carries the compiler
+      # versions: a new runner image invalidates the cache instead of
+      # handing the build modules it cannot read.
+      - name: Identify the toolchain the HDF5 cache is keyed on
+        id: toolchain
         run: |
-          wget https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_14_2.tar.gz
-          tar -xzf hdf5-1_14_2.tar.gz
-          cd hdf5-hdf5-1_14_2
-          ./configure FC=mpif90 CC=mpicc FCFLAGS=-O2 CFLAGS=-O2 CXX=mpic++ --enable-parallel --enable-static --enable-shared --enable-fortran --prefix=$HOME
+          set -e
+          {
+            gcc -dumpfullversion
+            gfortran -dumpfullversion
+            mpirun --version | head -n 1
+          } > toolchain.id
+          cat toolchain.id
+          echo "id=$(sha256sum toolchain.id | cut -c 1-12)" >> "$GITHUB_OUTPUT"
+
+      # Staged under a prefix of its own so the cache holds HDF5 and nothing
+      # else: TREXIO -- and, where it is built, QMCkl -- install into $HOME
+      # later in this job, and have versions of their own to track.
+      - name: Restore the HDF5 build
+        id: cache-hdf5
+        uses: actions/cache@v6
+        with:
+          path: ~/hdf5-install
+          key: hdf5-${{ env.HDF5_VERSION }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.id }}
+
+      - name: Build HDF5 from source
+        if: steps.cache-hdf5.outputs.cache-hit != 'true'
+        run: |
+          set -e
+          tag="hdf5-${HDF5_VERSION//./_}"
+          wget -q "https://github.com/HDFGroup/hdf5/archive/refs/tags/${tag}.tar.gz"
+          tar -xzf "${tag}.tar.gz"
+          cd "hdf5-${tag}"
+          ./configure FC=mpif90 CC=mpicc FCFLAGS=-O2 CFLAGS=-O2 CXX=mpic++ --enable-parallel --enable-static --enable-shared --enable-fortran --prefix=$HOME/hdf5-install
           make -j$(nproc)
           make install
+
+      # $HOME is the prefix every later step looks in, cached build or not.
+      - name: Install HDF5 into the dependency prefix
+        run: |
+          set -e
+          cp -a "$HOME/hdf5-install/." "$HOME/"
+          head -n 25 "$HOME/lib/libhdf5.settings"
 
       - name: Clone and Install TREXIO-v2.5.0
         run: |

--- a/.github/workflows/build_champ_trexio.yml
+++ b/.github/workflows/build_champ_trexio.yml
@@ -8,10 +8,26 @@ on:
     tags:
       - v2.*.*
       - v3.*.*
+    # Documentation and the Python tooling each have a workflow of their
+    # own; a change confined to them has nothing to build here.  Path
+    # filters are not evaluated for tag pushes, so a release is still
+    # built and tested in full.
+    paths-ignore:
+      - 'docs/**'
+      - 'tools/trex_tools/**'
+      - '**.md'
+      - '.github/workflows/build_documentation_devel.yml'
+      - '.github/workflows/test_python.yml'
   pull_request:
     branches:
       - 'releases/**'
       - main
+    paths-ignore:
+      - 'docs/**'
+      - 'tools/trex_tools/**'
+      - '**.md'
+      - '.github/workflows/build_documentation_devel.yml'
+      - '.github/workflows/test_python.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_champ_trexio.yml
+++ b/.github/workflows/build_champ_trexio.yml
@@ -62,7 +62,7 @@ jobs:
           make install
 
       - name: Clone the CHAMP code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Compile the CHAMP code with TREXIO using GNU compilers and run the TREXIO tests
         run: |

--- a/.github/workflows/build_champ_trexio.yml
+++ b/.github/workflows/build_champ_trexio.yml
@@ -8,10 +8,6 @@ on:
     tags:
       - v2.*.*
       - v3.*.*
-    # Documentation and the Python tooling each have a workflow of their
-    # own; a change confined to them has nothing to build here.  Path
-    # filters are not evaluated for tag pushes, so a release is still
-    # built and tested in full.
     paths-ignore:
       - 'docs/**'
       - 'tools/trex_tools/**'
@@ -31,8 +27,6 @@ on:
   workflow_dispatch:
 
 env:
-  # The one HDF5 the source-building workflows share; bump it here and the
-  # cache key follows.
   HDF5_VERSION: 1.14.2
 
 jobs:
@@ -58,12 +52,6 @@ jobs:
           which python
           python --version
 
-      # HDF5 is by a wide margin the slowest thing in this job, and what it
-      # produces depends only on the version and on the compilers that build
-      # it, so the installed tree is cached.  Fortran .mod files are tied to
-      # the exact gfortran that wrote them, so the key carries the compiler
-      # versions: a new runner image invalidates the cache instead of
-      # handing the build modules it cannot read.
       - name: Identify the toolchain the HDF5 cache is keyed on
         id: toolchain
         run: |
@@ -76,9 +64,6 @@ jobs:
           cat toolchain.id
           echo "id=$(sha256sum toolchain.id | cut -c 1-12)" >> "$GITHUB_OUTPUT"
 
-      # Staged under a prefix of its own so the cache holds HDF5 and nothing
-      # else: TREXIO -- and, where it is built, QMCkl -- install into $HOME
-      # later in this job, and have versions of their own to track.
       - name: Restore the HDF5 build
         id: cache-hdf5
         uses: actions/cache@v6
@@ -98,7 +83,6 @@ jobs:
           make -j$(nproc)
           make install
 
-      # $HOME is the prefix every later step looks in, cached build or not.
       - name: Install HDF5 into the dependency prefix
         run: |
           set -e

--- a/.github/workflows/build_champ_trexio.yml
+++ b/.github/workflows/build_champ_trexio.yml
@@ -28,6 +28,7 @@ on:
 
 env:
   HDF5_VERSION: 1.14.2
+  TREXIO_VERSION: 2.6.1
 
 jobs:
   build_champ_trexio:
@@ -89,11 +90,12 @@ jobs:
           cp -a "$HOME/hdf5-install/." "$HOME/"
           head -n 25 "$HOME/lib/libhdf5.settings"
 
-      - name: Clone and Install TREXIO-v2.5.0
+      - name: Clone and Install TREXIO
         run: |
-          wget https://github.com/TREX-CoE/trexio/releases/download/v2.5.0/trexio-2.5.0.tar.gz
-          tar -xzf trexio-2.5.0.tar.gz
-          cd trexio-2.5.0
+          set -e
+          wget -q "https://github.com/TREX-CoE/trexio/releases/download/v${TREXIO_VERSION}/trexio-${TREXIO_VERSION}.tar.gz"
+          tar -xzf "trexio-${TREXIO_VERSION}.tar.gz"
+          cd "trexio-${TREXIO_VERSION}"
           export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH
           cmake -S. -Bbuild \
             -DCMAKE_Fortran_COMPILER=mpif90 \

--- a/.github/workflows/build_champ_unit_test.yml
+++ b/.github/workflows/build_champ_unit_test.yml
@@ -3,10 +3,6 @@ name: CHAMP-EU CI - Unit tests for CHAMP with GNU using FortUTF
 on:
   pull_request:
     branches: [main]
-    # Documentation and the Python tooling each have a workflow of their
-    # own; a change confined to them has nothing to build here.  Path
-    # filters are not evaluated for tag pushes, so a release is still
-    # built and tested in full.
     paths-ignore:
       - 'docs/**'
       - 'tools/trex_tools/**'

--- a/.github/workflows/build_champ_unit_test.yml
+++ b/.github/workflows/build_champ_unit_test.yml
@@ -3,6 +3,16 @@ name: CHAMP-EU CI - Unit tests for CHAMP with GNU using FortUTF
 on:
   pull_request:
     branches: [main]
+    # Documentation and the Python tooling each have a workflow of their
+    # own; a change confined to them has nothing to build here.  Path
+    # filters are not evaluated for tag pushes, so a release is still
+    # built and tested in full.
+    paths-ignore:
+      - 'docs/**'
+      - 'tools/trex_tools/**'
+      - '**.md'
+      - '.github/workflows/build_documentation_devel.yml'
+      - '.github/workflows/test_python.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_champ_unit_test.yml
+++ b/.github/workflows/build_champ_unit_test.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   debug_build_test_champ:
     name: unit test with ${{ matrix.toolchain }} ${{ matrix.mode }} mode
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 20
     strategy:
       matrix:

--- a/.github/workflows/build_champ_unit_test.yml
+++ b/.github/workflows/build_champ_unit_test.yml
@@ -11,6 +11,9 @@ on:
       - '.github/workflows/test_python.yml'
   workflow_dispatch:
 
+env:
+  TREXIO_VERSION: 2.6.1
+
 jobs:
   debug_build_test_champ:
     name: unit test with ${{ matrix.toolchain }} ${{ matrix.mode }} mode
@@ -51,11 +54,12 @@ jobs:
 
     - name: Install Trexio
       run: |
-        wget https://github.com/TREX-CoE/trexio/releases/download/v1.0/trexio-1.0.0.tar.gz
-        tar -xzf trexio-1.0.0.tar.gz
-        cd trexio-1.0.0/
+        set -e
+        wget -q "https://github.com/TREX-CoE/trexio/releases/download/v${TREXIO_VERSION}/trexio-${TREXIO_VERSION}.tar.gz"
+        tar -xzf "trexio-${TREXIO_VERSION}.tar.gz"
+        cd "trexio-${TREXIO_VERSION}/"
         ./configure FC=gfortran CC=gcc
-        make all
+        make all -j$(nproc)
         make check
         sudo make install
         sudo cp include/* /usr/local/include/

--- a/.github/workflows/build_champ_unit_test.yml
+++ b/.github/workflows/build_champ_unit_test.yml
@@ -78,6 +78,7 @@ jobs:
         echo "mpirun used is " $MPIRUN
         cmake --version
         cmake -H. -Bbuild -DCMAKE_Fortran_COMPILER=mpif90 \
+                          -DCMAKE_C_COMPILER=mpicc \
                           -DCMAKE_BUILD_TYPE=${{ matrix.mode }} -DUNIT_TESTS=on
         cmake --build build -- vmc_Tests -j$(nproc)
         ulimit -s unlimited

--- a/.github/workflows/build_champ_unit_test.yml
+++ b/.github/workflows/build_champ_unit_test.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         shell: bash --noprofile --norc {0}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
 
     - name: Install Cmake and HDF5
       run: |

--- a/.github/workflows/build_champ_vmc_dmc.yml
+++ b/.github/workflows/build_champ_vmc_dmc.yml
@@ -28,6 +28,7 @@ on:
 
 env:
   HDF5_VERSION: 1.14.2
+  TREXIO_VERSION: 2.6.1
 
 jobs:
   build_champ_vmc_dmc:
@@ -89,11 +90,12 @@ jobs:
           cp -a "$HOME/hdf5-install/." "$HOME/"
           head -n 25 "$HOME/lib/libhdf5.settings"
 
-      - name: Clone and Install TREXIO-v2.5.0
+      - name: Clone and Install TREXIO
         run: |
-          wget https://github.com/TREX-CoE/trexio/releases/download/v2.5.0/trexio-2.5.0.tar.gz
-          tar -xzf trexio-2.5.0.tar.gz
-          cd trexio-2.5.0
+          set -e
+          wget -q "https://github.com/TREX-CoE/trexio/releases/download/v${TREXIO_VERSION}/trexio-${TREXIO_VERSION}.tar.gz"
+          tar -xzf "trexio-${TREXIO_VERSION}.tar.gz"
+          cd "trexio-${TREXIO_VERSION}"
           export LD_LIBRARY_PATH=$HOME/lib:$LD_LIBRARY_PATH
           cmake -S. -Bbuild \
             -DCMAKE_Fortran_COMPILER=mpif90 \

--- a/.github/workflows/build_champ_vmc_dmc.yml
+++ b/.github/workflows/build_champ_vmc_dmc.yml
@@ -8,10 +8,26 @@ on:
     tags:
       - v2.*.*
       - v3.*.*
+    # Documentation and the Python tooling each have a workflow of their
+    # own; a change confined to them has nothing to build here.  Path
+    # filters are not evaluated for tag pushes, so a release is still
+    # built and tested in full.
+    paths-ignore:
+      - 'docs/**'
+      - 'tools/trex_tools/**'
+      - '**.md'
+      - '.github/workflows/build_documentation_devel.yml'
+      - '.github/workflows/test_python.yml'
   pull_request:
     branches:
       - 'releases/**'
       - main
+    paths-ignore:
+      - 'docs/**'
+      - 'tools/trex_tools/**'
+      - '**.md'
+      - '.github/workflows/build_documentation_devel.yml'
+      - '.github/workflows/test_python.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_champ_vmc_dmc.yml
+++ b/.github/workflows/build_champ_vmc_dmc.yml
@@ -30,6 +30,11 @@ on:
       - '.github/workflows/test_python.yml'
   workflow_dispatch:
 
+env:
+  # The one HDF5 the source-building workflows share; bump it here and the
+  # cache key follows.
+  HDF5_VERSION: 1.14.2
+
 jobs:
   build_champ_vmc_dmc:
     strategy:
@@ -53,14 +58,52 @@ jobs:
           which python
           python --version
 
-      - name: Build HDF5 from source
+      # HDF5 is by a wide margin the slowest thing in this job, and what it
+      # produces depends only on the version and on the compilers that build
+      # it, so the installed tree is cached.  Fortran .mod files are tied to
+      # the exact gfortran that wrote them, so the key carries the compiler
+      # versions: a new runner image invalidates the cache instead of
+      # handing the build modules it cannot read.
+      - name: Identify the toolchain the HDF5 cache is keyed on
+        id: toolchain
         run: |
-          wget https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-1_14_2.tar.gz
-          tar -xzf hdf5-1_14_2.tar.gz
-          cd hdf5-hdf5-1_14_2
-          ./configure FC=mpif90 CC=mpicc FCFLAGS=-O2 CFLAGS=-O2 CXX=mpic++ --enable-parallel --enable-static --enable-shared --enable-fortran --prefix=$HOME
+          set -e
+          {
+            gcc -dumpfullversion
+            gfortran -dumpfullversion
+            mpirun --version | head -n 1
+          } > toolchain.id
+          cat toolchain.id
+          echo "id=$(sha256sum toolchain.id | cut -c 1-12)" >> "$GITHUB_OUTPUT"
+
+      # Staged under a prefix of its own so the cache holds HDF5 and nothing
+      # else: TREXIO -- and, where it is built, QMCkl -- install into $HOME
+      # later in this job, and have versions of their own to track.
+      - name: Restore the HDF5 build
+        id: cache-hdf5
+        uses: actions/cache@v6
+        with:
+          path: ~/hdf5-install
+          key: hdf5-${{ env.HDF5_VERSION }}-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.id }}
+
+      - name: Build HDF5 from source
+        if: steps.cache-hdf5.outputs.cache-hit != 'true'
+        run: |
+          set -e
+          tag="hdf5-${HDF5_VERSION//./_}"
+          wget -q "https://github.com/HDFGroup/hdf5/archive/refs/tags/${tag}.tar.gz"
+          tar -xzf "${tag}.tar.gz"
+          cd "hdf5-${tag}"
+          ./configure FC=mpif90 CC=mpicc FCFLAGS=-O2 CFLAGS=-O2 CXX=mpic++ --enable-parallel --enable-static --enable-shared --enable-fortran --prefix=$HOME/hdf5-install
           make -j$(nproc)
           make install
+
+      # $HOME is the prefix every later step looks in, cached build or not.
+      - name: Install HDF5 into the dependency prefix
+        run: |
+          set -e
+          cp -a "$HOME/hdf5-install/." "$HOME/"
+          head -n 25 "$HOME/lib/libhdf5.settings"
 
       - name: Clone and Install TREXIO-v2.5.0
         run: |

--- a/.github/workflows/build_champ_vmc_dmc.yml
+++ b/.github/workflows/build_champ_vmc_dmc.yml
@@ -8,10 +8,6 @@ on:
     tags:
       - v2.*.*
       - v3.*.*
-    # Documentation and the Python tooling each have a workflow of their
-    # own; a change confined to them has nothing to build here.  Path
-    # filters are not evaluated for tag pushes, so a release is still
-    # built and tested in full.
     paths-ignore:
       - 'docs/**'
       - 'tools/trex_tools/**'
@@ -31,8 +27,6 @@ on:
   workflow_dispatch:
 
 env:
-  # The one HDF5 the source-building workflows share; bump it here and the
-  # cache key follows.
   HDF5_VERSION: 1.14.2
 
 jobs:
@@ -58,12 +52,6 @@ jobs:
           which python
           python --version
 
-      # HDF5 is by a wide margin the slowest thing in this job, and what it
-      # produces depends only on the version and on the compilers that build
-      # it, so the installed tree is cached.  Fortran .mod files are tied to
-      # the exact gfortran that wrote them, so the key carries the compiler
-      # versions: a new runner image invalidates the cache instead of
-      # handing the build modules it cannot read.
       - name: Identify the toolchain the HDF5 cache is keyed on
         id: toolchain
         run: |
@@ -76,9 +64,6 @@ jobs:
           cat toolchain.id
           echo "id=$(sha256sum toolchain.id | cut -c 1-12)" >> "$GITHUB_OUTPUT"
 
-      # Staged under a prefix of its own so the cache holds HDF5 and nothing
-      # else: TREXIO -- and, where it is built, QMCkl -- install into $HOME
-      # later in this job, and have versions of their own to track.
       - name: Restore the HDF5 build
         id: cache-hdf5
         uses: actions/cache@v6
@@ -98,7 +83,6 @@ jobs:
           make -j$(nproc)
           make install
 
-      # $HOME is the prefix every later step looks in, cached build or not.
       - name: Install HDF5 into the dependency prefix
         run: |
           set -e

--- a/.github/workflows/build_champ_vmc_dmc.yml
+++ b/.github/workflows/build_champ_vmc_dmc.yml
@@ -62,7 +62,7 @@ jobs:
           make install
 
       - name: Clone the CHAMP code from GitHub
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Compile the CHAMP code with TREXIO using GNU compilers and run the VMC/DMC tests
         run: |

--- a/.github/workflows/build_documentation_devel.yml
+++ b/.github/workflows/build_documentation_devel.yml
@@ -1,7 +1,4 @@
 name: User Documentation
-# The documentation is self-contained: it is built from docs/ alone, so it
-# is rebuilt only when that tree (or this workflow) changes.  Nothing here
-# compiles CHAMP, and no CHAMP build depends on these files.
 on:
   push:
     branches:

--- a/.github/workflows/build_documentation_devel.yml
+++ b/.github/workflows/build_documentation_devel.yml
@@ -1,14 +1,24 @@
 name: User Documentation
+# The documentation is self-contained: it is built from docs/ alone, so it
+# is rebuilt only when that tree (or this workflow) changes.  Nothing here
+# compiles CHAMP, and no CHAMP build depends on these files.
 on:
   push:
     branches:
       - main
     tags:
       - '**'
+    paths:
+      - 'docs/**'
+      - '.github/workflows/build_documentation_devel.yml'
   pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/build_documentation_devel.yml'
   release:
     types:
       - published
+  workflow_dispatch:
 permissions:
   contents: read
   pages: write

--- a/.github/workflows/build_documentation_devel.yml
+++ b/.github/workflows/build_documentation_devel.yml
@@ -22,16 +22,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/configure-pages@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: 3.x
       - run: pip install zensical
       - run: |
           cd docs
           zensical build --clean
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/site
 
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
 # ---------------------------------------------------------------------
 # OLD DOXYGEN WORKFLOW (Commented out for future reference)

--- a/.github/workflows/debug_champ_intel_and_gnu.yml
+++ b/.github/workflows/debug_champ_intel_and_gnu.yml
@@ -3,10 +3,6 @@ name: CHAMP-EU CI - Debug build - Intel oneAPI and GNU toolchain
 on:
   push:
     branches: [main, ci_hotfix]
-    # Documentation and the Python tooling each have a workflow of their
-    # own; a change confined to them has nothing to build here.  Path
-    # filters are not evaluated for tag pushes, so a release is still
-    # built and tested in full.
     paths-ignore:
       - 'docs/**'
       - 'tools/trex_tools/**'
@@ -43,7 +39,6 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
-    # The same Intel toolchain the release build installs, step for step.
     - name: Use Intel oneAPI GitHub Actions fast setup
       if: matrix.toolchain == 'intel'
       uses: neelravi/intel-oneapi-github-actions@latest

--- a/.github/workflows/debug_champ_intel_and_gnu.yml
+++ b/.github/workflows/debug_champ_intel_and_gnu.yml
@@ -36,23 +36,19 @@ jobs:
       matrix:
         toolchain: ['intel','gnu']
         mode: ['RELEASE']
-        exclude:
-          - toolchain: 'intel'
-            mode: 'DEBUG'
       fail-fast: false
     defaults:
       run:
         shell: bash --noprofile --norc {0}
     steps:
     - uses: actions/checkout@v7
-    - name: Get Intel Key
+
+    # The same Intel toolchain the release build installs, step for step.
+    - name: Use Intel oneAPI GitHub Actions fast setup
       if: matrix.toolchain == 'intel'
-      run: |
-        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-        rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-        sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
-        sudo apt-get update
+      uses: neelravi/intel-oneapi-github-actions@latest
+      with:
+        components: basekit, hpckit
 
     - name: Install Cmake and HDF5
       run: |
@@ -70,20 +66,24 @@ jobs:
            sudo apt install -y gawk
            sudo apt install -y liblapack-dev
            sudo apt install -y libblas-dev
+           sudo apt install -y gcc
            gawk --version
            mpirun --version
            gfortran --version
+           gcc --version
 
-    - name: install Intel oneapi components
+    # The fast setup provides the C/C++ toolchain only; without ifx the
+    # mpiifx wrapper fails ("ifx: command not found").
+    - name: Install the Intel oneAPI Fortran compiler
       if: matrix.toolchain == 'intel'
       run: |
+        set -e
+        wget -qO- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+          | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/oneapi-archive-keyring.gpg
+        echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
+          | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update
-        sudo apt-get install -y intel-oneapi-common-vars
-        sudo apt-get install -y intel-oneapi-compiler-fortran-2021.3.0
-        sudo apt-get install -y intel-oneapi-mkl-2021.3.0
-        sudo apt-get install -y intel-oneapi-mkl-devel-2021.3.0
-        sudo apt-get install -y intel-oneapi-mpi-2021.3.0
-        sudo apt-get install -y intel-oneapi-mpi-devel-2021.3.0
+        sudo apt-get install -y intel-oneapi-compiler-fortran
 
     - name: Install Trexio
       run: |
@@ -106,12 +106,14 @@ jobs:
       run: |
         source /opt/intel/oneapi/setvars.sh
         printenv >> $GITHUB_ENV
-        which mpiifort
+        which mpiifx
         MPIRUN=`which mpirun`
         echo "mpirun used is " $MPIRUN
         cmake --version
-        # cmake -H. -Bbuild -DCMAKE_Fortran_COMPILER=mpiifort -DCMAKE_BUILD_TYPE=DEBUG
-        cmake -H. -Bbuild -DCMAKE_Fortran_COMPILER=mpiifort
+        ifx --version
+        icx --version
+        cmake -H. -Bbuild -DCMAKE_Fortran_COMPILER=mpiifx \
+                          -DCMAKE_C_COMPILER=mpiicx
         cmake --build build -- -j$(nproc)
         ulimit -s unlimited
 
@@ -123,7 +125,9 @@ jobs:
         MPIRUN=`which mpirun`
         echo "mpirun used is " $MPIRUN
         cmake --version
-        cmake -H. -Bbuild -DCMAKE_Fortran_COMPILER=mpif90 -DCMAKE_BUILD_TYPE=${{ matrix.mode }}
+        cmake -H. -Bbuild -DCMAKE_Fortran_COMPILER=mpif90 \
+                          -DCMAKE_C_COMPILER=mpicc \
+                          -DCMAKE_BUILD_TYPE=${{ matrix.mode }}
         cmake --build build -- -j$(nproc)
         ulimit -s unlimited
 

--- a/.github/workflows/debug_champ_intel_and_gnu.yml
+++ b/.github/workflows/debug_champ_intel_and_gnu.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   debug_build_test_champ:
     name: build and test with ${{ matrix.toolchain }} ${{ matrix.mode }} mode
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 200
     strategy:
       matrix:

--- a/.github/workflows/debug_champ_intel_and_gnu.yml
+++ b/.github/workflows/debug_champ_intel_and_gnu.yml
@@ -23,6 +23,9 @@ on:
         description: 'ctest label selector (-L), e.g. quick, VMC, H2O'
         default: "quick"
 
+env:
+  TREXIO_VERSION: 2.6.1
+
 jobs:
   debug_build_test_champ:
     name: build and test with ${{ matrix.toolchain }} ${{ matrix.mode }} mode
@@ -87,11 +90,12 @@ jobs:
         sudo apt-get install -y libhdf5-dev
         sudo apt-get install -y gfortran
         sudo apt-get install -y gcc
-        wget https://github.com/TREX-CoE/trexio/releases/download/v1.0/trexio-1.0.0.tar.gz
-        tar -xzf trexio-1.0.0.tar.gz
-        cd trexio-1.0.0/
+        set -e
+        wget -q "https://github.com/TREX-CoE/trexio/releases/download/v${TREXIO_VERSION}/trexio-${TREXIO_VERSION}.tar.gz"
+        tar -xzf "trexio-${TREXIO_VERSION}.tar.gz"
+        cd "trexio-${TREXIO_VERSION}/"
         ./configure FC=gfortran CC=gcc
-        make all
+        make all -j$(nproc)
         make check
         sudo make install
         sudo cp include/* /usr/local/include/

--- a/.github/workflows/debug_champ_intel_and_gnu.yml
+++ b/.github/workflows/debug_champ_intel_and_gnu.yml
@@ -28,7 +28,7 @@ jobs:
       run:
         shell: bash --noprofile --norc {0}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Get Intel Key
       if: matrix.toolchain == 'intel'
       run: |

--- a/.github/workflows/debug_champ_intel_and_gnu.yml
+++ b/.github/workflows/debug_champ_intel_and_gnu.yml
@@ -3,8 +3,24 @@ name: CHAMP-EU CI - Debug build - Intel oneAPI and GNU toolchain
 on:
   push:
     branches: [main, ci_hotfix]
+    # Documentation and the Python tooling each have a workflow of their
+    # own; a change confined to them has nothing to build here.  Path
+    # filters are not evaluated for tag pushes, so a release is still
+    # built and tested in full.
+    paths-ignore:
+      - 'docs/**'
+      - 'tools/trex_tools/**'
+      - '**.md'
+      - '.github/workflows/build_documentation_devel.yml'
+      - '.github/workflows/test_python.yml'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'tools/trex_tools/**'
+      - '**.md'
+      - '.github/workflows/build_documentation_devel.yml'
+      - '.github/workflows/test_python.yml'
   workflow_dispatch:
     inputs:
       tags:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,8 +3,24 @@ name: CHAMP-EU CI - Docker image build and tagging for Docker Hub
 on:
   push:
     branches: [ "main" ]
+    # Documentation and the Python tooling each have a workflow of their
+    # own; a change confined to them has nothing to build here.  Path
+    # filters are not evaluated for tag pushes, so a release is still
+    # built and tested in full.
+    paths-ignore:
+      - 'docs/**'
+      - 'tools/trex_tools/**'
+      - '**.md'
+      - '.github/workflows/build_documentation_devel.yml'
+      - '.github/workflows/test_python.yml'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - 'docs/**'
+      - 'tools/trex_tools/**'
+      - '**.md'
+      - '.github/workflows/build_documentation_devel.yml'
+      - '.github/workflows/test_python.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Build the Docker image
       run: |
         docker build . --file docker/GNU/Dockerfile --tag champ-gnu-${{ github.sha }}:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,10 +3,6 @@ name: CHAMP-EU CI - Docker image build and tagging for Docker Hub
 on:
   push:
     branches: [ "main" ]
-    # Documentation and the Python tooling each have a workflow of their
-    # own; a change confined to them has nothing to build here.  Path
-    # filters are not evaluated for tag pushes, so a release is still
-    # built and tested in full.
     paths-ignore:
       - 'docs/**'
       - 'tools/trex_tools/**'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,10 +12,6 @@ on:
     branches: [ "main" ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
-    # Documentation and the Python tooling each have a workflow of their
-    # own; a change confined to them has nothing to build here.  Path
-    # filters are not evaluated for tag pushes, so a release is still
-    # built and tested in full.
     paths-ignore:
       - 'docs/**'
       - 'tools/trex_tools/**'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,8 +12,24 @@ on:
     branches: [ "main" ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
+    # Documentation and the Python tooling each have a workflow of their
+    # own; a change confined to them has nothing to build here.  Path
+    # filters are not evaluated for tag pushes, so a release is still
+    # built and tested in full.
+    paths-ignore:
+      - 'docs/**'
+      - 'tools/trex_tools/**'
+      - '**.md'
+      - '.github/workflows/build_documentation_devel.yml'
+      - '.github/workflows/test_python.yml'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - 'docs/**'
+      - 'tools/trex_tools/**'
+      - '**.md'
+      - '.github/workflows/build_documentation_devel.yml'
+      - '.github/workflows/test_python.yml'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,27 +37,27 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3.6.0
+        uses: sigstore/cosign-installer@v4.1.2
         with:
-          cosign-release: 'v2.4.0'
+          cosign-release: 'v3.1.3'
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -67,7 +67,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
 
@@ -75,7 +75,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/GNU/Dockerfile

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -1,8 +1,5 @@
 name: CHAMP-EU CI - Python tests for the TREXIO tools integration
 
-# These are pure-Python tests: the trex2champ converter under
-# tools/trex_tools and the self-test of the CI test runner.  They need no
-# CHAMP build, so they run only when that Python code changes.
 on:
   push:
     branches: [main, ci_hotfix]

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -15,6 +15,9 @@ on:
       - '.github/workflows/test_python.yml'
   workflow_dispatch:
 
+env:
+  TREXIO_VERSION: 2.6.1
+
 jobs:
   build:
     name: TREXIO Github CI Python ${{ matrix.python-version }}
@@ -53,11 +56,12 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y gfortran
         sudo apt-get install -y gcc
-        wget https://github.com/TREX-CoE/trexio/releases/download/v2.4.2/trexio-2.4.2.tar.gz
-        tar -xzf trexio-2.4.2.tar.gz
-        cd trexio-2.4.2/
+        set -e
+        wget -q "https://github.com/TREX-CoE/trexio/releases/download/v${TREXIO_VERSION}/trexio-${TREXIO_VERSION}.tar.gz"
+        tar -xzf "trexio-${TREXIO_VERSION}.tar.gz"
+        cd "trexio-${TREXIO_VERSION}/"
         ./configure FC=gfortran CC=gcc
-        make all
+        make all -j$(nproc)
         make check
         sudo make install
         sudo cp include/* /usr/local/include/

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   build:
     name: TREXIO Github CI Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 200
     strategy:
       matrix:

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -20,9 +20,9 @@ jobs:
       run:
         shell: bash --noprofile --norc {0}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -21,11 +21,11 @@ env:
 jobs:
   build:
     name: TREXIO Github CI Python ${{ matrix.python-version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 200
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.12"]
       fail-fast: false
     defaults:
       run:

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -1,10 +1,21 @@
 name: CHAMP-EU CI - Python tests for the TREXIO tools integration
 
+# These are pure-Python tests: the trex2champ converter under
+# tools/trex_tools and the self-test of the CI test runner.  They need no
+# CHAMP build, so they run only when that Python code changes.
 on:
   push:
     branches: [main, ci_hotfix]
+    paths:
+      - 'tools/trex_tools/**'
+      - 'tests/CI_test/champ_test_runner.py'
+      - '.github/workflows/test_python.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'tools/trex_tools/**'
+      - 'tests/CI_test/champ_test_runner.py'
+      - '.github/workflows/test_python.yml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Addresses the Node.js 20 deprecation warning GitHub shows on nearly every
run, and takes four other passes over the workflows while the files are
open. One commit per task.

## What changed

**Node 24 action runtimes** (`452bb21a`)

Every action in the repository still declared `node20`, not just the two
named in the warning. Each moves to the current major, all of which
declare `node24`:

| action | before | after |
|---|---|---|
| `actions/checkout` | v2 / v3 / v4 | v7 |
| `actions/setup-python` | v3 / v5 | v7 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/configure-pages` | v5 | v6 |
| `actions/upload-pages-artifact` | v4 | v5 |
| `actions/deploy-pages` | v4 | v5 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/metadata-action` | v5 | v6 |
| `docker/build-push-action` | v6 | v7 |
| `sigstore/cosign-installer` | v3.6.0 | v4.1.2 |

The cosign installer is a composite action and was not part of the Node
warning, but its pinned cosign v2.4.0 was two majors behind; it moves to
v3.1.3 alongside. Every artifact name is already unique per job, so
nothing relied on the pre-v4 `upload-artifact` behaviour of appending to a
shared artifact.

**Workflows scoped to the files they own** (`8f3f1821`)

Previously a typo fixed in `docs/` compiled CHAMP four times over and built
two Docker images. The documentation and Python tests are self-contained,
so each declares its own tree and every build workflow ignores those trees:

| change | workflows that run |
|---|---|
| `docs/` only | documentation only |
| `tools/trex_tools/` only | Python tests only |
| Fortran sources | every build, no documentation |
| `README.md` only | nothing |

`tests/CI_test/champ_test_runner.py` is deliberately on both sides:
`test_python.yml` runs its selftest, and the `champ-test-values` action
calls it to collect every case's values, so a change there still runs the
builds.

**HDF5 build cached** (`bd98f786`)

Three workflows each built parallel HDF5 1.14.2 from source with identical
flags on every run. `actions/cache` now carries the installed tree. It is
staged under `~/hdf5-install` rather than straight into `$HOME`, because
`actions/cache` saves at the end of the job and a `$HOME`-rooted cache
would have swallowed TREXIO and QMCkl and served them back under an HDF5
key. The key carries the gcc, gfortran and OpenMPI versions, not just the
HDF5 version, so a runner image that bumps the compiler misses the cache
rather than being handed Fortran modules it cannot read. The key is
identical in all three, so the first job to build serves the other two.

**One toolchain per compiler** (`0570c932`)

CI claimed two toolchains and tested three. The release build used
`mpiifx`/`mpiicx` (ifx, icx); the debug build pinned oneAPI 2021.3.0 and
called `mpiifort` — a compiler Intel has since removed from oneAPI. The
debug leg now installs Intel exactly as the release leg does. On the GNU
side the unit-test and debug builds passed only
`-DCMAKE_Fortran_COMPILER=mpif90`, leaving CMake to pick plain `cc` for the
C sources; both now pass `mpicc` as well.

**TREXIO 2.6.1 everywhere** (`3a77925a`)

Six workflows were pulling three versions — 2.5.0, 2.4.2, and 1.0.0 from
2021. All six now take 2.6.1 from a workflow-level `TREXIO_VERSION`.
Verified under cmake with `mpif90`/`mpicc` (TREXIO's own ctest 27/27) and
under autotools with `gfortran`/`gcc` (`make check` clean), plus the wheel
opening the committed `benzene.hdf5` fixture with the trex2champ tests
passing.

**ubuntu-26.04 where it is ready** (`c478a50c`)

Every workflow was replayed on an Ubuntu 26.04.1 machine before anything
changed. Five move: `build_champ_intel` (30/30), `build_champ_qmckl`,
`build_champ_unit_test` (5/5), `debug_champ_intel_and_gnu` (both legs 6/6)
and `test_python` (3/3). `build_champ_trexio` and `build_champ_vmc_dmc`
stay on ubuntu-22.04 and will follow separately.

## For the reviewer

- **`ubuntu-26.04` is a public-preview image.** `actionlint` 1.7.12 does
  not know the label yet and flags it; declaring it as a self-hosted label
  in a local config clears the whole tree.
- **The Python matrix moves off 3.8**, which is not built for the 26.04
  image at all, to 3.12. The ceiling matters as much as the floor: TREXIO
  publishes wheels only through cp313, and above that pip falls back to the
  sdist and builds without the HDF5 back end. 3.10–3.13 is the usable
  window.
- **Path filters are not evaluated for tag pushes**, so `v2.*.*` / `v3.*.*`
  release tags still trigger a full build and test of every workflow
  regardless of what the tagged commit touched.
- **`main` has neither branch protection nor a ruleset** requiring these
  checks, so a workflow skipped by a path filter cannot leave a pull
  request waiting on a check that will never report. Worth re-checking if
  required checks are added later.
- **Separate finding, not fixed here:** the `components: basekit, hpckit`
  input to `neelravi/intel-oneapi-github-actions` is split on the comma
  without trimming, so the action looks for `␣hpckit`, logs
  `Unknown component:  hpckit` and never installs it — visible in current
  CI logs on main. It works today only because `intel-basekit` pulls Intel
  MPI in as a dependency. A one-character fix in that repository, but it
  changes what gets installed, so it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
